### PR TITLE
fix _scan_for_children to recurse into dict constraint returns

### DIFF
--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -107,6 +107,9 @@ class Model(CostedConstraintSet):
                 if isinstance(items, Model):
                     if items not in self._children:
                         self._children.append(items)
+                elif isinstance(items, dict):
+                    for item in items.values():
+                        _scan_for_children(item)
                 elif isinstance(items, list):
                     for item in items:
                         _scan_for_children(item)

--- a/gpkit/tests/test_model_graph.py
+++ b/gpkit/tests/test_model_graph.py
@@ -67,6 +67,27 @@ class TestModelGraph:
         assert t.submodels[0] is t.a
         assert t.submodels[1] is t.b
 
+    def test_dict_return_children_detected(self):
+        """Children inside a dict constraint return are found by _scan_for_children."""
+
+        class _MGInner(Model):
+            def setup(self):
+                x = Variable("x")
+                self.cost = x
+                return [x >= 1]
+
+        class _MGOuter(Model):
+            inner: "_MGInner"
+
+            def setup(self):
+                W = Variable("W")
+                self.inner = _MGInner()
+                self.cost = W
+                return {"constraints": [self.inner, W >= self.inner.cost * 1.1]}
+
+        m = _MGOuter()
+        assert m.submodels == [m.inner]
+
     def test_children_of_same_class_are_distinguishable(self):
         """Two children of the same class are distinguished by attr name."""
 


### PR DESCRIPTION
Fixes #136.

`_scan_for_children` in `Model.__init__` recursed into lists but silently fell through for dicts, so child `Model` instances returned inside a dict from `setup()` were never added to `_children` and were invisible to `submodels`, `walk()`, and `get_var()`.

Fix mirrors the existing pattern in `ConstraintSet._collect`, which already handles dicts by iterating over their values. Added a failing test first to confirm the bug, then the two-line fix.