### PR TITLE
Report: rich model descriptions, references, and objective section

### DIFF
--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -1,6 +1,6 @@
 "GP and SP modeling package"
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 import numpy as _np
 

--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -180,8 +180,8 @@ class Model(CostedConstraintSet):  # pylint: disable=too-many-instance-attribute
         """
         return {
             "summary": (cls.__doc__ or "").strip(),
-            "assumptions": [],  # discrete modeling choices, separate from prose summary
-            "references": [],
+            "assumptions": list(getattr(cls, "assumptions", [])),
+            "references": list(getattr(cls, "references", [])),
         }
 
     def get_var(self, path: str):

--- a/gpkit/report.py
+++ b/gpkit/report.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any, List, Optional, Tuple
 
 from .constraints.tight import Tight
+from .model import Model as _Model
 from .printing import _format_aligned_columns
 from .util.repr_conventions import unitstr
 from .util.small_classes import Quantity
@@ -71,6 +72,17 @@ class ReportSection:  # pylint: disable=too-many-instance-attributes
     is_anonymous: bool = False  # True for bare Model(...) instances (no subclass name)
     children: list = field(default_factory=list)  # list of ReportSection
     lineage_map: dict = field(default_factory=dict)  # NOT in to_dict
+    references: list = field(default_factory=list)  # list of str
+    front_matter: str = ""  # raw text/MD prepended at root only
+    toc: bool = (
+        False  # insert TOC marker (supported by renderers that have a native facility)
+    )
+    objective_str: str = ""  # text representation of cost expression; "" if constant
+    objective_latex: str = ""  # LaTeX representation of cost expression
+    objective_value: Optional[float] = (
+        None  # magnitude of attained cost; None if unsolved
+    )
+    objective_units: str = ""  # unit string for the cost expression
 
     def to_dict(self) -> dict:
         """JSON-serializable dict (for format='dict' and future API)."""
@@ -81,6 +93,13 @@ class ReportSection:  # pylint: disable=too-many-instance-attributes
             "is_anonymous": self.is_anonymous,
             "description": self.description,
             "assumptions": list(self.assumptions),
+            "references": list(self.references),
+            "front_matter": self.front_matter,
+            "toc": self.toc,
+            "objective_str": self.objective_str,
+            "objective_latex": self.objective_latex,
+            "objective_value": self.objective_value,
+            "objective_units": self.objective_units,
             "free_variables": [v.to_dict() for v in self.free_variables],
             "fixed_variables": [v.to_dict() for v in self.fixed_variables],
             "constraint_groups": [
@@ -305,6 +324,27 @@ def _build_constraint_groups(model) -> List[CGroup]:
     return [CGroup(label="", constraints=own)] if own else []
 
 
+def _build_objective(model, solution) -> dict:
+    """Return objective keyword args for ReportSection for the model's cost.
+
+    All fields are empty/None when the cost has no variables (i.e. it is a
+    trivial constant placeholder rather than a real optimization objective).
+    """
+    if not model.cost.vks:
+        return {
+            "objective_str": "",
+            "objective_latex": "",
+            "objective_value": None,
+            "objective_units": "",
+        }
+    return {
+        "objective_str": model.cost.str_without({"units"}),
+        "objective_latex": model.cost.latex({"units"}),
+        "objective_value": float(solution.cost) if solution is not None else None,
+        "objective_units": unitstr(model.cost),
+    }
+
+
 # ── Core builder ─────────────────────────────────────────────────────────────
 
 
@@ -312,6 +352,8 @@ def build_report_ir(
     model,
     solution=None,
     _parent_path: str = "",
+    front_matter: str = "",
+    toc: bool = False,
 ) -> ReportSection:
     """Build a ReportSection tree from *model*.
 
@@ -321,9 +363,14 @@ def build_report_ir(
         Root model to report on.
     solution : Solution, optional
         If provided, variable entries include solved values and sensitivities.
+    front_matter : str, optional
+        Raw text/markdown prepended before the report.  Set only on the root
+        ReportSection; not propagated to children.
+    toc : bool, optional
+        If True, a table-of-contents marker is inserted by renderers that have
+        a native TOC facility (e.g. ``[TOC]`` in Markdown).  Set only on the
+        root ReportSection; not propagated to children.
     """
-    from .model import Model as _Model  # pylint: disable=import-outside-toplevel
-
     is_anon = type(model) is _Model  # pylint: disable=unidiomatic-typecheck
     own_name = "" if is_anon else type(model).__name__
     if own_name:
@@ -337,10 +384,15 @@ def build_report_ir(
         solution,
         extra_vks=_collect_constraint_varkeys(cgroups) - model.unique_varkeys,
     )
+    if is_anon:
+        desc = {"summary": "", "assumptions": [], "references": []}
+    else:
+        desc = type(model).description()
     return ReportSection(
         title=own_name or "Model",
-        description="[description]",
-        assumptions=[],
+        description=desc["summary"],
+        assumptions=desc["assumptions"],
+        references=desc["references"],
         lineage_path=lineage_path,
         magic_prefix=model.lineagestr(),
         is_anonymous=is_anon,
@@ -348,6 +400,9 @@ def build_report_ir(
         fixed_variables=fixed_vars,
         constraint_groups=cgroups,
         lineage_map=lineage_map,
+        front_matter=front_matter,
+        toc=toc,
+        **_build_objective(model, solution),
         children=[
             build_report_ir(child, solution=solution, _parent_path=lineage_path)
             for child in model.submodels
@@ -499,6 +554,32 @@ def _text_constraint_rows(constraints: list, lineage_map: dict = None) -> list:
     return _format_aligned_columns(c_rows, "<<", "  ")
 
 
+def _text_prose_lines(ir: "ReportSection", pad: str) -> list:
+    """Return prose lines: description, assumptions, references, objective."""
+    lines = []
+    if ir.description:
+        lines.append(f"{pad}  {ir.description}")
+        lines.append("")
+    if ir.assumptions:
+        lines.append(f"{pad}  Assumptions:")
+        for item in ir.assumptions:
+            lines.append(f"{pad}    - {item}")
+        lines.append("")
+    if ir.references:
+        lines.append(f"{pad}  References:")
+        for item in ir.references:
+            lines.append(f"{pad}    - {item}")
+        lines.append("")
+    if ir.objective_str:
+        lines.append(f"{pad}  Objective")
+        lines.append(f"{pad}    minimize: {ir.objective_str}")
+        if ir.objective_value is not None:
+            val_str = _fmt_value(ir.objective_value)
+            lines.append(f"{pad}    attained: {val_str} {ir.objective_units}".rstrip())
+        lines.append("")
+    return lines
+
+
 def render_text(ir: "ReportSection", indent: int = 0) -> str:
     """Render a ReportSection tree as hierarchical plain text.
 
@@ -516,6 +597,11 @@ def render_text(ir: "ReportSection", indent: int = 0) -> str:
     pad = _INDENT * indent
     lines: list = []
 
+    # Front matter (root only)
+    if ir.front_matter:
+        lines.append(ir.front_matter)
+        lines.append("")
+
     if ir.is_anonymous:
         # Transparent wrapper: no header, children rendered at the same level
         child_indent = indent
@@ -524,17 +610,7 @@ def render_text(ir: "ReportSection", indent: int = 0) -> str:
         lines.append(f"{pad}{ir.lineage_path or ir.title}")
         child_indent = indent + 1
 
-    # Description
-    if ir.description:
-        lines.append(f"{pad}  {ir.description}")
-        lines.append("")
-
-    # Assumptions
-    if ir.assumptions:
-        lines.append(f"{pad}  Assumptions:")
-        for assumption in ir.assumptions:
-            lines.append(f"{pad}    - {assumption}")
-        lines.append("")
+    lines.extend(_text_prose_lines(ir, pad))
 
     # Optimized Variables table (primal — no sensitivity column)
     if ir.free_variables:
@@ -608,6 +684,28 @@ def _md_var_table(variables: list, include_sensitivity: bool = False) -> list:
     return lines
 
 
+def _md_prose_lines(ir: "ReportSection") -> list:
+    """Return markdown lines for description, assumptions, references, and objective."""
+    lines = []
+    if ir.description:
+        lines.append(ir.description)
+        lines.append("")
+    if ir.assumptions:
+        lines.append(f"**Assumptions:** {'; '.join(ir.assumptions)}")
+        lines.append("")
+    if ir.references:
+        lines.append(f"**References:** {'; '.join(ir.references)}")
+        lines.append("")
+    if ir.objective_str:
+        lines.append(f"**Objective:** minimize $${ir.objective_latex}$$")
+        if ir.objective_value is not None:
+            val_str = _fmt_value(ir.objective_value)
+            attained = f"{val_str} {ir.objective_units}".rstrip()
+            lines.append(f"**Attained:** {attained}")
+        lines.append("")
+    return lines
+
+
 def render_markdown(ir: "ReportSection", level: int = 1) -> str:
     """Render a ReportSection tree as Markdown.
 
@@ -625,6 +723,14 @@ def render_markdown(ir: "ReportSection", level: int = 1) -> str:
     hdr = "#" * min(level, 6)
     lines: list = []
 
+    # Front matter and TOC marker (root only, before first heading)
+    if ir.front_matter:
+        lines.append(ir.front_matter)
+        lines.append("")
+    if ir.toc:
+        lines.append("[TOC]")
+        lines.append("")
+
     if ir.is_anonymous:
         # Transparent wrapper: skip heading, children rendered at same level
         child_level = level
@@ -634,16 +740,7 @@ def render_markdown(ir: "ReportSection", level: int = 1) -> str:
         lines.append("")
         child_level = level + 1
 
-    # Description
-    if ir.description:
-        lines.append(ir.description)
-        lines.append("")
-
-    # Assumptions
-    if ir.assumptions:
-        assumption_str = "; ".join(ir.assumptions)
-        lines.append(f"**Assumptions:** {assumption_str}")
-        lines.append("")
+    lines.extend(_md_prose_lines(ir))
 
     # Optimized Variables pipe table (no sensitivity column)
     if ir.free_variables:

--- a/gpkit/tests/test_report.py
+++ b/gpkit/tests/test_report.py
@@ -645,3 +645,21 @@ class TestModelDescription:
         assert "references" in d
         assert isinstance(d["assumptions"], list)
         assert isinstance(d["references"], list)
+
+    def test_model_description_class_attrs(self):
+        """Class-attr assumptions/references are included via description()."""
+
+        class _DescAttrs(Model):
+            """Aerodynamics model."""
+
+            assumptions = ["incompressible flow", "steady state"]
+            references = ["Anderson 2001"]
+
+            def setup(self):
+                x = Variable("x_desc_attrs")
+                return [x >= 1]
+
+        d = _DescAttrs.description()
+        assert d["summary"] == "Aerodynamics model."
+        assert d["assumptions"] == ["incompressible flow", "steady state"]
+        assert d["references"] == ["Anderson 2001"]

--- a/gpkit/tests/test_report_descriptions.py
+++ b/gpkit/tests/test_report_descriptions.py
@@ -328,9 +328,8 @@ class TestObjective:
     """Tests for objective expression and value in ReportSection and renderers."""
 
     def _solved_box(self):
-        from gpkit.examples.simple_box import (
-            Box,  # pylint: disable=import-outside-toplevel
-        )
+        # pylint: disable=import-outside-toplevel
+        from gpkit.examples.simple_box import Box
 
         m = Box()
         sol = m.solve(verbosity=0)

--- a/gpkit/tests/test_report_descriptions.py
+++ b/gpkit/tests/test_report_descriptions.py
@@ -1,0 +1,470 @@
+"""Tests for model description metadata, IR wiring, and renderer output.
+
+Split from test_report.py to keep that file within the line-count limit.
+Covers: Model.description(), class-attr assumptions/references, ReportSection
+fields (references, front_matter, toc, objective_*), build_report_ir wiring,
+and renderer output for all new fields.
+"""
+
+import pytest
+
+from gpkit import Model, Variable
+from gpkit.report import (
+    ReportSection,
+    build_report_ir,
+    render_markdown,
+    render_text,
+)
+
+# ── ReportSection references / front_matter / toc fields ─────────────────────
+
+
+class TestReportSectionReferences:
+    """Tests for references, front_matter, and toc fields on ReportSection."""
+
+    def test_references_field_exists(self):
+        """ReportSection has a references field defaulting to []."""
+        ir = ReportSection(
+            title="Wing",
+            description="",
+            assumptions=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+        )
+        assert not ir.references
+
+    def test_references_in_to_dict(self):
+        """ReportSection.to_dict() includes references."""
+        ir = ReportSection(
+            title="Wing",
+            description="",
+            assumptions=[],
+            references=["Anderson 2001"],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+        )
+        d = ir.to_dict()
+        assert "references" in d
+        assert d["references"] == ["Anderson 2001"]
+
+    def test_front_matter_field_exists(self):
+        """ReportSection has a front_matter field defaulting to ''."""
+        ir = ReportSection(
+            title="Aircraft",
+            description="",
+            assumptions=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+        )
+        assert ir.front_matter == ""
+
+    def test_toc_field_exists(self):
+        """ReportSection has a toc field defaulting to False."""
+        ir = ReportSection(
+            title="Aircraft",
+            description="",
+            assumptions=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+        )
+        assert ir.toc is False
+
+    def test_front_matter_toc_in_to_dict(self):
+        """front_matter and toc appear in to_dict()."""
+        ir = ReportSection(
+            title="Aircraft",
+            description="",
+            assumptions=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+            front_matter="# Study",
+            toc=True,
+        )
+        d = ir.to_dict()
+        assert d["front_matter"] == "# Study"
+        assert d["toc"] is True
+
+
+# ── build_report_ir description wiring ───────────────────────────────────────
+
+
+class TestBuildReportIRDescription:
+    """build_report_ir() pulls description from model.description() classmethod."""
+
+    def test_build_ir_description_from_docstring(self):
+        """build_report_ir uses docstring as section description."""
+
+        class _IRAero(Model):
+            """Aerodynamics submodel."""
+
+            def setup(self):
+                x = Variable("x_ir_aero")
+                return [x >= 1]
+
+        ir = build_report_ir(_IRAero())
+        assert ir.description == "Aerodynamics submodel."
+
+    def test_build_ir_assumptions_from_description(self):
+        """build_report_ir populates assumptions from model.description()."""
+
+        class _IRAss(Model):
+            def setup(self):
+                x = Variable("x_ir_ass")
+                return [x >= 1]
+
+            @classmethod
+            def description(cls):
+                return {
+                    "summary": "Test",
+                    "assumptions": ["beam theory"],
+                    "references": [],
+                }
+
+        ir = build_report_ir(_IRAss())
+        assert "beam theory" in ir.assumptions
+
+    def test_build_ir_references_from_description(self):
+        """build_report_ir populates references from model.description()."""
+
+        class _IRRef(Model):
+            def setup(self):
+                x = Variable("x_ir_ref")
+                return [x >= 1]
+
+            @classmethod
+            def description(cls):
+                return {
+                    "summary": "",
+                    "assumptions": [],
+                    "references": ["Drela 2013"],
+                }
+
+        ir = build_report_ir(_IRRef())
+        assert "Drela 2013" in ir.references
+
+    def test_build_ir_class_attrs_wired(self):
+        """build_report_ir picks up class-attr assumptions/references."""
+
+        class _IRClassAttr(Model):
+            """Structural model."""
+
+            assumptions = ["no buckling"]
+            references = ["Raymer 2018"]
+
+            def setup(self):
+                x = Variable("x_ir_cls")
+                return [x >= 1]
+
+        ir = build_report_ir(_IRClassAttr())
+        assert ir.description == "Structural model."
+        assert "no buckling" in ir.assumptions
+        assert "Raymer 2018" in ir.references
+
+    def test_build_ir_anonymous_no_description(self):
+        """Anonymous model sections have empty description, assumptions, references."""
+        x = Variable("x_ir_anon")
+        m = Model(1 / x, [x >= 1])
+        ir = build_report_ir(m)
+        assert ir.description == ""
+        assert not ir.assumptions
+        assert not ir.references
+
+    def test_build_ir_front_matter_kwarg(self):
+        """build_report_ir passes front_matter to root ReportSection only."""
+
+        class _IRFM(Model):
+            def setup(self):
+                x = Variable("x_ir_fm")
+                return [x >= 1]
+
+        ir = build_report_ir(_IRFM(), front_matter="# Study\nIntro text.")
+        assert ir.front_matter == "# Study\nIntro text."
+
+    def test_build_ir_toc_kwarg(self):
+        """build_report_ir passes toc=True to root ReportSection."""
+
+        class _IRToc(Model):
+            def setup(self):
+                x = Variable("x_ir_toc")
+                return [x >= 1]
+
+        ir = build_report_ir(_IRToc(), toc=True)
+        assert ir.toc is True
+
+
+# ── Renderer: references ──────────────────────────────────────────────────────
+
+
+class TestRenderReferences:
+    """Tests that renderers include references output."""
+
+    def _ir_with_refs(self):
+        return ReportSection(
+            title="Wing",
+            description="A wing model.",
+            assumptions=["steady state"],
+            references=["Anderson 2001", "Drela 2013"],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+        )
+
+    def test_render_text_references(self):
+        """render_text includes references block when present."""
+        out = render_text(self._ir_with_refs())
+        assert "Anderson 2001" in out
+        assert "Drela 2013" in out
+
+    def test_render_markdown_references(self):
+        """render_markdown includes **References:** line when present."""
+        out = render_markdown(self._ir_with_refs())
+        assert "**References:**" in out
+        assert "Anderson 2001" in out
+        assert "Drela 2013" in out
+
+    def test_render_text_no_references_block_when_empty(self):
+        """render_text omits references block when list is empty."""
+        ir = ReportSection(
+            title="Wing",
+            description="",
+            assumptions=[],
+            references=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+        )
+        out = render_text(ir)
+        assert "References" not in out
+
+    def test_render_markdown_no_references_when_empty(self):
+        """render_markdown omits **References:** when list is empty."""
+        ir = ReportSection(
+            title="Wing",
+            description="",
+            assumptions=[],
+            references=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+        )
+        out = render_markdown(ir)
+        assert "**References:**" not in out
+
+
+# ── Renderer: front_matter and toc ───────────────────────────────────────────
+
+
+class TestRenderFrontMatterToc:
+    """Tests that renderers handle front_matter and toc fields."""
+
+    def test_render_markdown_front_matter(self):
+        """render_markdown prepends front_matter text before the root heading."""
+        ir = ReportSection(
+            title="Aircraft",
+            description="",
+            assumptions=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+            front_matter="# Design Study\nIntroductory text.",
+        )
+        out = render_markdown(ir)
+        assert out.startswith("# Design Study")
+        assert "Introductory text." in out
+
+    def test_render_markdown_toc_marker(self):
+        """render_markdown inserts [TOC] marker when toc=True."""
+        ir = ReportSection(
+            title="Aircraft",
+            description="",
+            assumptions=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+            toc=True,
+        )
+        out = render_markdown(ir)
+        assert "[TOC]" in out
+
+    def test_render_text_front_matter(self):
+        """render_text prepends front_matter before the section header."""
+        ir = ReportSection(
+            title="Aircraft",
+            description="",
+            assumptions=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+            front_matter="Intro text.",
+        )
+        out = render_text(ir)
+        assert out.startswith("Intro text.")
+
+    def test_render_text_toc_ignored(self):
+        """render_text silently ignores toc=True (no TOC facility in plain text)."""
+        ir = ReportSection(
+            title="Aircraft",
+            description="",
+            assumptions=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+            toc=True,
+        )
+        # Should not raise; output is plain text with no [TOC] marker
+        out = render_text(ir)
+        assert "[TOC]" not in out
+
+
+# ── Objective section ─────────────────────────────────────────────────────────
+
+
+class TestObjective:
+    """Tests for objective expression and value in ReportSection and renderers."""
+
+    def _solved_box(self):
+        from gpkit.examples.simple_box import (
+            Box,  # pylint: disable=import-outside-toplevel
+        )
+
+        m = Box()
+        sol = m.solve(verbosity=0)
+        return m, sol
+
+    def test_objective_fields_on_report_section(self):
+        """ReportSection has all four objective_* fields defaulting to empty/None."""
+        ir = ReportSection(
+            title="Test",
+            description="",
+            assumptions=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+        )
+        assert ir.objective_str == ""
+        assert ir.objective_latex == ""
+        assert ir.objective_value is None
+        assert ir.objective_units == ""
+
+    def test_objective_in_to_dict(self):
+        """ReportSection.to_dict() includes all four objective fields."""
+        ir = ReportSection(
+            title="Test",
+            description="",
+            assumptions=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[],
+            objective_str="1/(h·w·d)",
+            objective_latex=r"\frac{1}{h w d}",
+            objective_value=3.67e-3,
+            objective_units="1/m³",
+        )
+        d = ir.to_dict()
+        assert d["objective_str"] == "1/(h·w·d)"
+        assert d["objective_latex"] == r"\frac{1}{h w d}"
+        assert pytest.approx(d["objective_value"]) == 3.67e-3
+        assert d["objective_units"] == "1/m³"
+
+    def test_build_ir_populates_objective_unsolved(self):
+        """build_report_ir sets objective_str and latex even without a solution."""
+
+        class _ObjModel(Model):
+            def setup(self):
+                x = Variable("x_obj", "m")
+                y = Variable("y_obj", "m")
+                self.cost = x * y
+                return [x >= y, y >= x]
+
+        m = _ObjModel()
+        ir = build_report_ir(m)
+        assert ir.objective_str != ""
+        assert ir.objective_latex != ""
+        assert ir.objective_value is None  # no solution provided
+        assert ir.objective_units != ""
+
+    def test_build_ir_populates_objective_solved(self):
+        """build_report_ir populates objective_value from solution."""
+        m, sol = self._solved_box()
+        ir = build_report_ir(m, solution=sol)
+        assert ir.objective_value is not None
+        assert ir.objective_value == pytest.approx(sol.cost)
+
+    def test_build_ir_objective_empty_for_constant_cost(self):
+        """build_report_ir leaves objective fields empty when cost has no variables."""
+
+        class _ConstCost(Model):
+            def setup(self):
+                x = Variable("x_cc")
+                return [x >= 1]
+
+        m = _ConstCost()
+        ir = build_report_ir(m)
+        assert ir.objective_str == ""
+        assert ir.objective_latex == ""
+
+    def test_build_ir_objective_empty_for_submodel(self):
+        """Child models in a hierarchy have empty objective fields."""
+
+        class _Child(Model):
+            def setup(self):
+                x = Variable("x_child_obj")
+                return [x >= 1]
+
+        class _Parent(Model):
+            child = None  # set in setup()
+
+            def setup(self):
+                self.child = _Child()
+                x = Variable("x_child_obj2")
+                y = Variable("y_parent_obj")
+                self.cost = y
+                return [self.child, y >= x, x >= 1]
+
+        m = _Parent()
+        ir = build_report_ir(m)
+        assert ir.objective_str != ""  # parent has a real cost
+        assert ir.children[0].objective_str == ""  # child does not
+
+    def test_render_text_objective(self):
+        """render_text includes objective expression and value when present."""
+        m, sol = self._solved_box()
+        out = m.report(solution=sol, fmt="text")
+        assert "Objective" in out
+        assert "minimize" in out.lower()
+
+    def test_render_markdown_objective(self):
+        """render_markdown includes objective heading and value when present."""
+        m, sol = self._solved_box()
+        out = m.report(solution=sol, fmt="md")
+        assert "Objective" in out
+        assert "minimize" in out.lower()
+
+    def test_render_text_no_objective_when_empty(self):
+        """render_text omits objective section when cost has no variables."""
+
+        class _NoObj(Model):
+            def setup(self):
+                x = Variable("x_noobj")
+                return [x >= 1]
+
+        m = _NoObj()
+        out = m.report(fmt="text")
+        assert "Objective" not in out
+
+    def test_render_markdown_no_objective_when_empty(self):
+        """render_markdown omits objective section when cost has no variables."""
+
+        class _NoObjMd(Model):
+            def setup(self):
+                x = Variable("x_noobjmd")
+                return [x >= 1]
+
+        m = _NoObjMd()
+        out = m.report(fmt="md")
+        assert "Objective" not in out


### PR DESCRIPTION
## Summary

- **Model metadata**: `Model.description()` now reads `assumptions` and `references` class attributes (in addition to the docstring), so authors can document a submodel with zero boilerplate:
  ```python
  class Wing(Model):
      """Structural wing model based on beam theory."""
      assumptions = ["isotropic material", "no buckling"]
      references  = ["Raymer 2018 Ch. 14"]
  ```
  A full `description()` classmethod override is still supported for complete control.

- **IR fields**: `ReportSection` gains `references`, `front_matter`, `toc`, and four `objective_*` fields (`objective_str`, `objective_latex`, `objective_value`, `objective_units`). All appear in `to_dict()`.

- **Description wiring**: `build_report_ir()` now calls `model.description()` for every section instead of the `"[description]"` placeholder. Anonymous (bare `Model`) instances stay transparent with empty fields. Accepts `front_matter` and `toc` kwargs that set the root section only.

- **Objective section**: `build_report_ir()` populates objective fields from `model.cost` when the cost has variables (i.e. is a real objective, not the default `Monomial(1)`). When a solution is provided, `objective_value` is set from `solution.cost`.

- **Renderers**: `render_text()` and `render_markdown()` render all new fields. The prose block (description → assumptions → references → objective) is extracted into `_text_prose_lines()` / `_md_prose_lines()` helpers, keeping both renderers within pylint's branch/statement limits.

- **Import cleanup**: `from .model import Model` moved to module level in `report.py` (was a deferred local import to avoid a circular dependency that does not actually exist).

- **Tests**: New `test_report_descriptions.py` covers all new behavior (test-first). `test_report.py` was split to stay within the 1000-line module limit.

## Test plan

- [x] `uv run pytest gpkit/tests/test_report.py gpkit/tests/test_report_descriptions.py -q` — 68 tests pass
- [x] `uv run pylint --rcfile=.pylintrc --ignore=examples gpkit/` — 10.00/10, no violations
- [x] `make pylint` — clean
- [x] Smoke test: instantiate `Box`, call `m.report(fmt="text")` and `m.report(solution=sol, fmt="md")` — objective section appears with expression and attained value