### PR TITLE
hotfix (and tests) for CGroup dicts in reports

### DIFF
--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -1,6 +1,6 @@
 "GP and SP modeling package"
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 import numpy as _np
 

--- a/gpkit/report.py
+++ b/gpkit/report.py
@@ -299,33 +299,48 @@ def _build_split_var_entries(
     return free_entries, fixed_entries
 
 
+def _collect_leaf_constraints(container) -> list:
+    """Recursively collect single-equation leaf constraints from a container.
+
+    Unwraps Tight; skips other ConstraintSet subclasses and Models (identified
+    by unique_varkeys); flattens lists and tuples.
+
+    Known limitation: only Tight is unwrapped. Other transparent wrappers
+    (Loose, Bounded, SignomialEquality, ConstraintsRelaxed*) are silently
+    dropped — the isinstance(Tight) check is not a principled protocol.
+    """
+    result = []
+    for item in container:
+        if isinstance(item, Tight):
+            result.extend(_collect_leaf_constraints(item))
+        elif hasattr(item, "unique_varkeys"):
+            pass  # skip child Models and other ConstraintSet subclasses
+        elif isinstance(item, (list, tuple)):
+            result.extend(_collect_leaf_constraints(item))
+        else:
+            result.append(item)
+    return result
+
+
 def _build_constraint_groups(model) -> List[CGroup]:
     """Build CGroup list from model.cgroups or a single unnamed group.
 
-    Raw constraint objects are stored; renderers call str() or .latex() as
-    appropriate. to_dict() serializes via str().
+    CGroup.constraints holds only leaf (single-equation) constraints;
+    Tight wrappers are unwrapped so every item accepts .latex(excluded,
+    aligned=True). Raw objects are stored; renderers call str() or .latex().
     """
     if model.cgroups is not None:
         return [
             CGroup(
                 label=label,
-                constraints=list(items if isinstance(items, list) else [items]),
+                constraints=_collect_leaf_constraints(
+                    items if isinstance(items, list) else [items]
+                ),
             )
             for label, items in model.cgroups.items()
         ]
 
-    def _collect_own(container):
-        for item in container:
-            if isinstance(item, Tight):
-                yield from _collect_own(item)  # treat contents as bare constraints
-            elif hasattr(item, "unique_varkeys"):
-                continue  # skip child Models and ConstraintSets
-            elif isinstance(item, (list, tuple)):
-                yield from _collect_own(item)
-            else:
-                yield item
-
-    own = list(_collect_own(model))
+    own = _collect_leaf_constraints(model)
     return [CGroup(label="", constraints=own)] if own else []
 
 

--- a/gpkit/tests/test_report.py
+++ b/gpkit/tests/test_report.py
@@ -6,6 +6,7 @@ import pytest
 
 import gpkit
 from gpkit import Model, Variable
+from gpkit.constraints.tight import Tight
 from gpkit.report import (
     CGroup,
     ReportSection,
@@ -165,6 +166,40 @@ class TestBuildReportIR:
         group_labels = [cg.label for cg in ir.constraint_groups]
         assert "Drag" in group_labels
         assert "Lift" in group_labels
+
+    def test_build_report_ir_dict_cgroups_with_tight(self):
+        """dict cgroups with Tight-wrapped list produce leaf CGroup constraints."""
+
+        class _RSDictTight(Model):
+            def setup(self):
+                x = Variable("x_rsdt")
+                y = Variable("y_rsdt")
+                return {"Structural": [Tight([x >= 1, y >= x])]}
+
+        m = _RSDictTight()
+        ir = build_report_ir(m)
+        assert ir.constraint_groups[0].label == "Structural"
+        # Tight should be unwrapped: two leaf constraints, not a Tight object
+        for c in ir.constraint_groups[0].constraints:
+            assert not isinstance(
+                c, Tight
+            ), "Tight should be unwrapped into leaf constraints"
+
+    def test_report_md_dict_cgroups_with_tight(self):
+        """model.report(fmt='md') with Tight in dict cgroups must not raise."""
+
+        class _MDDictTight(Model):
+            def setup(self):
+                x = Variable("x_mddt")
+                y = Variable("y_mddt")
+                return {"Structural": [Tight([x >= 1, y >= x])]}
+
+        m = _MDDictTight()
+        # previously raised TypeError: unexpected keyword argument 'aligned'
+        result = m.report(fmt="md")
+        assert "Structural" in result
+        # variable names appear in LaTeX form, e.g. x_{\text{mddt}}
+        assert "mddt" in result
 
     def test_var_entry_uses_pretty_unit_format(self):
         """build_report_ir uses platform-appropriate pretty format in VarEntry.units."""


### PR DESCRIPTION
## Summary

- Fixes a `TypeError` (`unexpected keyword argument 'aligned'`) when calling `model.report(fmt='md')` on a model whose `setup()` returns a dict with `Tight`-wrapped constraints
- Fixes the same underlying inconsistency in `render_text`
- Adds two regression tests

## Root cause

`_build_constraint_groups` had two paths. The non-dict path used a local `_collect_own` that recursively unwrapped `Tight` wrappers, ensuring only leaf constraints reached `CGroup.constraints`. The dict path did a shallow `list(items)`, so a `Tight` instance inside a dict value passed through intact. The markdown renderer then called `Tight.latex(excluded, aligned=True)`, but `ConstraintSet.latex()` has no `aligned` parameter.

## Changes

- Extracted `_collect_own` into module-level `_collect_leaf_constraints`, applied to both the dict and non-dict paths — `CGroup.constraints` now consistently holds only leaf constraints regardless of how the model is defined
- Two tests: one verifying `Tight` is unwrapped at the IR level, one verifying `report(fmt='md')` doesn't raise

## Known limitation (flagged, not fixed)

Only `Tight` is unwrapped. Other transparent ConstraintSet wrappers (`Loose`, `Bounded`, `SignomialEquality`, `ConstraintsRelaxed*`) would be silently dropped if placed in a dict cgroup value. The `isinstance(Tight)` check is not a principled protocol — a follow-up issue should define a proper "transparent wrapper" protocol.