### PR TITLE
Fix: use identity checks in _scan_for_children to prevent silent child drops

### DIFF
--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -91,7 +91,7 @@ class Model(CostedConstraintSet):  # pylint: disable=too-many-instance-attribute
         # instances — only direct Model instances count.
         def _scan_for_children(items):
             if isinstance(items, Model):
-                if items not in self._children:
+                if not any(items is child for child in self._children):
                     self._children.append(items)
             elif isinstance(items, dict):
                 for item in items.values():
@@ -124,7 +124,9 @@ class Model(CostedConstraintSet):  # pylint: disable=too-many-instance-attribute
             _scan_for_children(constraints)
             # Map attribute names to child models (for get_var() path resolution)
             for attr_name, val in list(self.__dict__.items()):
-                if isinstance(val, Model) and val in self._children:
+                if isinstance(val, Model) and any(
+                    val is child for child in self._children
+                ):
                     self._child_attrs[attr_name] = val
         else:
             if args and not substitutions:

--- a/gpkit/tests/test_model_graph.py
+++ b/gpkit/tests/test_model_graph.py
@@ -88,6 +88,28 @@ class TestModelGraph:
         m = _MGOuter()
         assert m.submodels == [m.inner]
 
+    def test_two_identical_empty_children_both_registered(self):
+        """Two distinct instances of an empty model must both appear in _children.
+
+        Regression: _scan_for_children used list `in` (which calls __eq__) rather
+        than identity checks, so two empty models ([] == []) collapsed to one.
+        """
+
+        class _EmptyChild(Model):
+            def setup(self):
+                return []
+
+        class _Parent(Model):
+            def setup(self):
+                c1 = _EmptyChild()
+                c2 = _EmptyChild()
+                self.cost = Variable("W")
+                return [self.cost >= 1, c1, c2]
+
+        p = _Parent()
+        assert len(p.submodels) == 2
+        assert p.submodels[0] is not p.submodels[1]
+
     def test_children_of_same_class_are_distinguishable(self):
         """Two children of the same class are distinguished by attr name."""
 


### PR DESCRIPTION
## Summary

- `_scan_for_children` used `items not in self._children` to deduplicate child models. Because `Model` inherits from `list`, this calls `list.__eq__` — structural content comparison — not identity. Two distinct empty (or same-content) model instances compare equal, so the second was silently dropped from `_children`.
- The same hazard existed on the companion check that builds `_child_attrs`.
- Both checks are replaced with explicit `is` comparisons.
- A regression test is added that creates two distinct `_EmptyChild()` instances as siblings and asserts both appear in `submodels`.

Relates to #137 (ConstraintSet list inheritance). A comment on that issue explains how fixing #95 would eliminate this hazard class entirely.

## Test plan

- [ ] New test `test_two_identical_empty_children_both_registered` fails before the fix and passes after
- [ ] All 18 model graph tests pass
- [ ] Full test suite passes (`719 passed, 3 skipped`)