### PR TITLE
Fix: escape ^ in markdown unit strings to prevent pandoc superscript misparse

### DIFF
--- a/gpkit/report.py
+++ b/gpkit/report.py
@@ -853,7 +853,7 @@ def _split_constraint_str(c_str: str):
 
 def _md_escape(text: str) -> str:
     r"""Escape characters that have special meaning in markdown pipe tables."""
-    for ch in ("\\", "|", "*", "_", "`", "~", "[", "]", "<", ">", "%"):
+    for ch in ("\\", "|", "*", "_", "`", "~", "[", "]", "<", ">", "%", "^"):
         text = text.replace(ch, "\\" + ch)
     return text
 
@@ -872,7 +872,7 @@ def _md_var_table(variables: list, include_sensitivity: bool = False) -> list:
         cells = [name_cell]
         if has_source:
             cells.append(_md_escape(ve.source))
-        cells += [_fmt_value(ve.value), ve.units]
+        cells += [_fmt_value(ve.value), _md_escape(ve.units)]
         if include_sensitivity:
             cells.append(_fmt_sensitivity(ve.sensitivity))
         cells.append(_md_escape(ve.label))

--- a/gpkit/tests/test_report.py
+++ b/gpkit/tests/test_report.py
@@ -13,6 +13,7 @@ from gpkit.report import (
     VarEntry,
     _fmt_value,
     _md_escape,
+    _md_var_table,
     _serialize_value,
     build_report_ir,
     render_markdown,
@@ -600,6 +601,26 @@ class TestRenderMarkdown:
         assert _md_escape("no specials") == "no specials"
         assert _md_escape("a_b*c|d") == r"a\_b\*c\|d"
         assert _md_escape("~95% TD") == r"\~95\% TD"
+
+    def test_md_var_table_unit_caret_escaped(self):
+        """Units with ASCII ^ are escaped so pandoc does not treat them as superscript.
+
+        pandoc's superscript extension turns ^text^ into <sup>text</sup>, so a
+        unit string like 'km^2/s^2' in a pipe-table cell renders as
+        km<sup>2/s</sup>2 in HTML.  The fix escapes ^ to \\^ so it is literal.
+        """
+        ve = VarEntry(
+            name="v",
+            latex="v",
+            value=1.0,
+            sensitivity=None,
+            units="km^2/s^2",
+            label="specific energy",
+        )
+        lines = _md_var_table([ve])
+        table_str = "\n".join(lines)
+        assert r"km\^2/s\^2" in table_str  # caret must be escaped
+        assert "km^2/s^2" not in table_str  # raw unescaped caret must not appear
 
 
 # ── Tests moved from test_model.py (cgroups + description) ──────────────────


### PR DESCRIPTION
## Summary

- `_md_escape` now escapes `^` in addition to the other pandoc-special characters
- `_md_var_table` applies `_md_escape` to `ve.units` (previously unescaped)

## Problem

pandoc's superscript extension treats `^text^` (two carets, no spaces) as `<sup>text</sup>`. A unit string like `km^2/s^2` in a pipe-table cell would render as `km<sup>2/s</sup>2` — visually `km^{2/s} 2`.

## Test

Added `test_md_var_table_unit_caret_escaped` to `TestRenderMarkdown`: creates a `VarEntry` with `units="km^2/s^2"` and asserts the output contains `km\^2/s\^2` (escaped) and not the raw `km^2/s^2`.