### PR TITLE
Raise descriptive error for degenerate constraint in _simplify_posy_ineq

### DIFF
--- a/gpkit/nomials/math.py
+++ b/gpkit/nomials/math.py
@@ -479,6 +479,12 @@ class PosynomialInequality(ScalarSingleEquationConstraint):
             if fixed:
                 msg += f" after substituting {fixed}."
             raise PrimalInfeasible(msg)
+        if not coeff:
+            raise InvalidGPConstraint(
+                "Degenerate constraint: all monomials evaluated to zero"
+                " coefficient. Check that no substituted value forces a"
+                f" constraint coefficient to zero. Constraint: {self}"
+            )
         scaled = hmap / coeff
         scaled.units = hmap.units
         del scaled[EMPTY_HV]

--- a/gpkit/tests/test_constraints.py
+++ b/gpkit/tests/test_constraints.py
@@ -22,6 +22,7 @@ from gpkit.constraints.relax import (
 from gpkit.constraints.tight import Tight
 from gpkit.exceptions import InvalidGPConstraint, PrimalInfeasible
 from gpkit.nomials import MonomialEquality, PosynomialInequality, SignomialInequality
+from gpkit.nomials.substitution import parse_subs
 from gpkit.units import DimensionalityError
 from gpkit.util.globals import NamedVariables
 
@@ -182,6 +183,21 @@ class TestConstraint:
             m.solve(verbosity=0)
         PosynomialInequality.feastol = 1e-3
         assert m.substitutions["x"] == m.solve(verbosity=0)[x]
+
+    def test_degenerate_constraint_at_construction(self):
+        "Constant term exactly equal to RHS at construction raises descriptive error"
+        x = Variable("x")
+        with pytest.raises(InvalidGPConstraint, match="Degenerate constraint"):
+            _ = x + 1 <= 1
+
+    def test_degenerate_constraint_via_substitution(self):
+        "Substitution making constant term equal to RHS raises descriptive error"
+        x = Variable("x")
+        y = Variable("y")
+        c = x + y <= 1
+        subs = parse_subs(c.vks, {y: 1})
+        with pytest.raises(InvalidGPConstraint, match="Degenerate constraint"):
+            c.as_hmapslt1(subs)
 
 
 class TestCostedConstraint:


### PR DESCRIPTION
## Summary

- Catches the `ZeroDivisionError` that occurs in `_simplify_posy_ineq` when `coeff == 0` (i.e. the constant term exactly equals the full RHS budget), replacing it with a clear `InvalidGPConstraint` message that names the constraint and tells the user to check for substitutions that zero out coefficients.
- Adds two tests: one triggering the degenerate case at construction time (`x + 1 <= 1`), and one via substitution using `parse_subs` to properly exercise the `pmap`-tracking code path.

## Test plan

- [x] `test_degenerate_constraint_at_construction` — verifies `InvalidGPConstraint` with "Degenerate constraint" message is raised when a literal constant equals the RHS at creation time
- [x] `test_degenerate_constraint_via_substitution` — verifies the same error is raised when a substitution drives the constant term to equal the RHS
- [x] Full test suite (`uv run pytest gpkit/tests/`) passes (722 passed, 3 skipped)