### PR TITLE
Remove [margin] label from budget output

### DIFF
--- a/gpkit/budgets.py
+++ b/gpkit/budgets.py
@@ -443,14 +443,9 @@ def _attach_sub_budget(node, child_vk, ctx, remaining_depth=float("inf")):
 
 def _process_term(top_vk, term, ctx, remaining_depth=float("inf")):
     """Build a single BudgetNode for one term in a budget constraint's RHS."""
-    is_self_ref = top_vk in term.exp
     free_in_term = {vk for vk in term.exp if vk not in ctx.solution.constants}
     parent_prefix = top_vk.lineagestr() if top_vk.lineage else None
-    is_simple = (
-        not is_self_ref
-        and len(free_in_term) == 1
-        and term.exp.get(next(iter(free_in_term))) == 1
-    )
+    is_simple = len(free_in_term) == 1 and term.exp.get(next(iter(free_in_term))) == 1
     if is_simple:
         child_vk = next(iter(free_in_term))
         if term.ast_label is not None:
@@ -499,8 +494,6 @@ def _process_term(top_vk, term, ctx, remaining_depth=float("inf")):
         if term.ast_label is not None
         else _format_term_label(term.exp, term.phys_coeff, strip_prefix=parent_prefix)
     )
-    if is_self_ref:
-        label += " [margin]"
     return BudgetNode(
         label=label,
         vk=None,

--- a/gpkit/tests/test_budgets.py
+++ b/gpkit/tests/test_budgets.py
@@ -68,21 +68,6 @@ class Aircraft(Model):
         return [self.m >= self.wing.m, self.wing]
 
 
-class AircraftWithMargin(Model):
-    """Budget constraint includes a self-referential margin term."""
-
-    wing: Wing
-    m: Variable
-
-    def setup(self):
-        self.wing = Wing()
-        f_margin = Variable("f_margin", 0.1, label="mass margin fraction")
-        self.m = Variable("m", "kg", "total mass")
-        self.cost = self.m
-        # m >= wing.m + f_margin * m  →  m*(1-0.1) >= wing.m  at optimum
-        return [self.m >= self.wing.m + f_margin * self.m, self.wing]
-
-
 class SlackModel(Model):
     """Budget constraint that is NOT tight at the optimum.
 
@@ -225,38 +210,6 @@ class TestBuildBudgetBasic:
         assert wing_node.label == "Wing.m"
         spar_node = next(n for n in wing_node.children if abs(n.value - 10) < 1e-3)
         assert spar_node.label == "Spar.m"
-
-
-# ---------------------------------------------------------------------------
-# Tests: build_budget — margin / self-referential term
-# ---------------------------------------------------------------------------
-
-
-class TestBuildBudgetMargin:
-    """Tests for build_budget() with self-referential margin terms."""
-
-    def test_margin_term_present(self):
-        model = AircraftWithMargin()
-        sol, _ = solve(model)
-        b = build_budget(sol, model, model.m)
-        labels = [n.label for n in b.children]
-        assert any("[margin]" in lbl for lbl in labels)
-
-    def test_margin_term_value(self):
-        model = AircraftWithMargin()
-        sol, _ = solve(model)
-        b = build_budget(sol, model, model.m)
-        margin_nodes = [n for n in b.children if "[margin]" in n.label]
-        assert len(margin_nodes) == 1
-        # f_margin = 0.1, wing.m = 15 kg → m_total ≈ 16.67 kg, margin ≈ 1.67 kg
-        assert margin_nodes[0].value > 0
-
-    def test_children_sum_with_margin(self):
-        model = AircraftWithMargin()
-        sol, _ = solve(model)
-        b = build_budget(sol, model, model.m)
-        child_sum = sum(n.value for n in b.children)
-        assert abs(child_sum - b.total) / b.total < 1e-4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Budget terms that reference the budget variable on their own RHS (e.g. `f_margin * m` in `m >= wing.m + f_margin * m`) were being labeled `[margin]` in budget output. This was the wrong abstraction: the code was detecting a mathematical property (self-reference) and interpreting it as engineering semantics (a design reserve), which doesn't generalize. Any self-referential term — growth factor, safety factor, fuel fraction — would get the same label regardless of intent.

Removes the `is_self_ref` detection, the special-case guard in `is_simple`, and the `[margin]` suffix. Self-referential terms now go through the normal compound-term path and are labeled by their expression. Also removes the `AircraftWithMargin` test fixture and `TestBuildBudgetMargin` class that existed solely to test this behavior; the general `test_children_sum_to_total` coverage already handles the correctness property that mattered.