### PR TITLE
Drop redundant single-monomial leaf rows from budgets; fix #185

### DIFF
--- a/docs/source/examples/growth_allowance_output.txt
+++ b/docs/source/examples/growth_allowance_output.txt
@@ -1,6 +1,6 @@
 Budget  —  Wing.m
 -----------------
              Nominal  Growth  Total              
-  Wing.m          27    8.64  35.64  [kg]  100.0%
-    Spar.m      13.5     2.7   16.2  [kg]   45.5%
-    Spar1.m     13.5     2.7   16.2  [kg]   45.5%
+  Wing.m        32.4    3.24  35.64  [kg]  100.0%
+    Spar.m      16.2       0   16.2  [kg]   45.5%
+    Spar1.m     16.2       0   16.2  [kg]   45.5%

--- a/docs/source/examples/growth_allowance_output.txt
+++ b/docs/source/examples/growth_allowance_output.txt
@@ -1,6 +1,6 @@
 Budget  —  Wing.m
 -----------------
              Nominal  Growth  Total              
-  Wing.m        32.4    3.24  35.64  [kg]  100.0%
-    Spar.m      16.2       0   16.2  [kg]   45.5%
-    Spar1.m     16.2       0   16.2  [kg]   45.5%
+  Wing.m          27    8.64  35.64  [kg]  100.0%
+    Spar.m      13.5     2.7   16.2  [kg]   45.5%
+    Spar1.m     13.5     2.7   16.2  [kg]   45.5%

--- a/docs/source/examples/growth_allowance_output.txt
+++ b/docs/source/examples/growth_allowance_output.txt
@@ -1,8 +1,6 @@
 Budget  —  Wing.m
 -----------------
-               Nominal  Growth  Total              
-  Wing.m            27    8.64  35.64  [kg]  100.0%
-    Spar.m        13.5     2.7   16.2  [kg]   45.5%
-      rho·t·A     13.5           13.5  [kg]   83.3%
-    Spar1.m       13.5     2.7   16.2  [kg]   45.5%
-      rho·t·A     13.5           13.5  [kg]   83.3%
+             Nominal  Growth  Total              
+  Wing.m          27    8.64  35.64  [kg]  100.0%
+    Spar.m      13.5     2.7   16.2  [kg]   45.5%
+    Spar1.m     13.5     2.7   16.2  [kg]   45.5%

--- a/gpkit/budgets.py
+++ b/gpkit/budgets.py
@@ -225,9 +225,6 @@ class BudgetNode:  # pylint: disable=too-many-instance-attributes
     cbe_value: float = 0.0
     ga_value: float = 0.0
     has_growth: bool = False
-    # True when the term is a bare variable (e.g. ``m``); false for compound
-    # expressions (``rho*A``, ``1/m``, ``2*m``) that get suppressed when alone.
-    is_var: bool = False
 
 
 @dataclass
@@ -546,24 +543,13 @@ def _attach_sub_budget(node, child_vk, ctx, remaining_depth=float("inf")):
         node.ga_value = node.value * peeled_frac
 
 
-def _term_is_var(term):
-    "True when *term* is a bare variable reference."
-    if term.ast_label is not None:
-        # AST tracked the term — trust its var/expression classification.
-        return term.is_var_node is True
-    if len(term.exp) != 1:
-        return False
-    (exp_value,) = term.exp.values()
-    return exp_value == 1 and abs(term.phys_coeff - 1.0) <= 1e-10
-
-
 def _process_term(top_vk, term, ctx, remaining_depth=float("inf")):
     """Build a single BudgetNode for one term in a budget constraint's RHS.
 
     Bare-variable terms (``m``, ``m_min``) become recursable nodes — we try
     to expand a sub-budget below them.  Compound terms (``rho*A``, ``1/m``,
-    ``2*m``) become non-recursing leaves; ``_is_redundant_leaf`` drops them
-    when they're the only child of their parent.
+    ``2*m``) become non-recursing leaves; ``_is_redundant_compound_leaf``
+    drops them when they're the only child of their parent.
     """
     parent_prefix = top_vk.lineagestr() if top_vk.lineage else None
     is_var = _term_is_var(term)
@@ -582,7 +568,6 @@ def _process_term(top_vk, term, ctx, remaining_depth=float("inf")):
             fraction=0.0,
             slack=0.0,
             units=ctx.level_units,
-            is_var=False,
         )
     (child_vk,) = term.exp.keys()
     label = (
@@ -605,7 +590,6 @@ def _process_term(top_vk, term, ctx, remaining_depth=float("inf")):
         fraction=0.0,
         slack=0.0,
         units=units,
-        is_var=True,
     )
     if (
         child_vk not in ctx.visited
@@ -615,6 +599,17 @@ def _process_term(top_vk, term, ctx, remaining_depth=float("inf")):
     ):
         _attach_sub_budget(node, child_vk, ctx, remaining_depth=remaining_depth - 1)
     return node
+
+
+def _term_is_var(term):
+    "True when *term* is a bare variable reference."
+    if term.ast_label is not None:
+        # AST tracked the term — trust its var/expression classification.
+        return term.is_var_node is True
+    if len(term.exp) != 1:
+        return False
+    (exp_value,) = term.exp.values()
+    return exp_value == 1 and abs(term.phys_coeff - 1.0) <= 1e-10
 
 
 def _is_allowance_term(term, parent_vk):
@@ -627,9 +622,9 @@ def _is_allowance_term(term, parent_vk):
     return vk.name == f"{parent_vk.name}_growth" and vk.lineage == parent_vk.lineage
 
 
-def _is_monomial_leaf(nodes):
+def _is_redundant_compound_leaf(nodes):
     "True when *nodes* is a single compound (non-bare-var) row — drop it."
-    return len(nodes) == 1 and not nodes[0].is_var
+    return len(nodes) == 1 and nodes[0].vk is None
 
 
 def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
@@ -674,7 +669,7 @@ def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
             )
         else:
             slack_frac = 0.0
-    if _is_monomial_leaf(nodes):
+    if _is_redundant_compound_leaf(nodes):
         # Compound monomial expression as a lone child — visually redundant
         # with the parent's value; drop it regardless of depth.
         return [], peeled_frac, slack_frac

--- a/gpkit/budgets.py
+++ b/gpkit/budgets.py
@@ -539,6 +539,11 @@ def _attach_sub_budget(node, child_vk, ctx, remaining_depth=float("inf")):
     )
     node.has_growth = peeled_frac > 0
     node.slack = slack_frac
+    if not node.children and peeled_frac > 0:
+        # Suppression dropped the lone non-growth (compound) term; record
+        # this level's peeled growth so _compute_cbe_ga's leaf branch can
+        # derive cbe = value − ga correctly.
+        node.ga_value = node.value * peeled_frac
 
 
 def _term_is_var(term):
@@ -677,7 +682,12 @@ def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
 
 
 def _compute_cbe_ga(node):
-    """Post-order: cbe = sum of leaf values; ga = value − cbe.
+    """Post-order cbe/ga split.
+
+    Non-leaves: ``cbe`` is the sum of children's cbe; ``ga`` is the
+    remainder.  Leaves: ``ga_value`` is pre-set in ``_attach_sub_budget``
+    when growth was peeled but the lone non-growth term was suppressed
+    (zero otherwise); ``cbe`` is derived from it.
 
     Also propagates ``has_growth`` up: a node has growth if it owns a peeled
     allowance (set in _attach_sub_budget) or any descendant does.
@@ -687,9 +697,9 @@ def _compute_cbe_ga(node):
             _compute_cbe_ga(child)
         node.cbe_value = sum(c.cbe_value for c in node.children)
         node.has_growth = node.has_growth or any(c.has_growth for c in node.children)
+        node.ga_value = node.value - node.cbe_value
     else:
-        node.cbe_value = node.value
-    node.ga_value = node.value - node.cbe_value
+        node.cbe_value = node.value - node.ga_value
 
 
 def _resolve_vk(var):
@@ -784,7 +794,11 @@ def build_budget(  # pylint: disable=too-many-locals
     )
     for child in children:
         _compute_cbe_ga(child)
-    cbe_total = sum(c.cbe_value for c in children) if children else total_val
+    cbe_total = (
+        sum(c.cbe_value for c in children)
+        if children
+        else total_val * (1.0 - peeled_frac)
+    )
     has_growth = peeled_frac > 0 or any(c.has_growth for c in children)
     return Budget(
         top_vk=top_vk,

--- a/gpkit/budgets.py
+++ b/gpkit/budgets.py
@@ -15,7 +15,6 @@ Usage example::
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -176,6 +175,12 @@ def find_budget_constraints(model, vk, solution):
     return sorted(matches, key=lambda x: -x[2])
 
 
+def _drop_nonbinding(matches, threshold=1e-5):
+    "Drop near-zero-sensitivity matches when at least one binding match remains."
+    binding = [m for m in matches if m[2] > threshold]
+    return binding if binding else matches
+
+
 # ---------------------------------------------------------------------------
 # Data structures
 # ---------------------------------------------------------------------------
@@ -220,6 +225,9 @@ class BudgetNode:  # pylint: disable=too-many-instance-attributes
     cbe_value: float = 0.0
     ga_value: float = 0.0
     has_growth: bool = False
+    # True when a sub-budget exists but expansion was deliberately stopped
+    # (e.g. multiple tight bounds on the same variable — ambiguous).
+    terminate: bool = False
 
 
 @dataclass
@@ -512,14 +520,15 @@ def _make_term(mon, hmap_units, ast_labels, ast_is_var, ctx):
 def _attach_sub_budget(node, child_vk, ctx, remaining_depth=float("inf")):
     "Recursively attach sub-budget children to *node* if a budget constraint exists."
     sub_matches = find_budget_constraints(ctx.model, child_vk, ctx.solution)
+    if len(sub_matches) > 1:
+        sub_matches = _drop_nonbinding(sub_matches)
     if not sub_matches:
         return
     if len(sub_matches) > 1:
-        warnings.warn(
-            f"Multiple budget constraints for {child_vk}; "
-            "using highest-sensitivity one.",
-            stacklevel=5,
-        )
+        # Multiple genuinely tight bounds — stop expansion. Mark the node so
+        # the caller doesn't treat its empty children as a redundant leaf.
+        node.terminate = True
+        return
     sub_c, sub_lt = sub_matches[0][0], sub_matches[0][1]
     child_units = child_vk.unitrepr if child_vk.unitrepr != "-" else "dimensionless"
     sub_ctx = _BudgetCtx(
@@ -529,12 +538,11 @@ def _attach_sub_budget(node, child_vk, ctx, remaining_depth=float("inf")):
         level_units=child_units,
         visited=ctx.visited | {child_vk},
     )
-    node.children, peeled_frac = _build_children(
+    node.children, peeled_frac, slack_frac = _build_children(
         child_vk, sub_lt, sub_c, sub_ctx, remaining_depth=remaining_depth
     )
     node.has_growth = peeled_frac > 0
-    non_slack_frac = sum(c.fraction for c in node.children if c.label != "[slack]")
-    node.slack = max(0.0, 1.0 - non_slack_frac - peeled_frac)
+    node.slack = slack_frac
 
 
 def _process_term(top_vk, term, ctx, remaining_depth=float("inf")):
@@ -610,12 +618,24 @@ def _is_allowance_term(term, parent_vk):
     return vk.name == f"{parent_vk.name}_growth" and vk.lineage == parent_vk.lineage
 
 
+def _is_redundant_leaf(nodes, peeled_frac):
+    "True when *nodes* is a single child that visually duplicates its parent."
+    if peeled_frac != 0.0 or len(nodes) != 1:
+        return False
+    only = nodes[0]
+    return not only.children and not only.terminate and only.label != "[slack]"
+
+
 def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
     """Recursively build BudgetNode children from the lt side of a budget constraint.
 
     When *top_vk* declares a growth allowance, the auto-generated allowance
     term in its budget constraint is peeled off rather than rendered as a
     child row — its value flows into the parent's ``ga_value`` instead.
+
+    Returns ``(nodes, peeled_frac, slack_frac)``.  ``slack_frac`` is the
+    constraint's relative slack (0 when tight) so callers don't have to
+    reverse-engineer it from child fractions.
     """
     total_val = float(ctx.solution[top_vk].to(ctx.level_units).magnitude)
     is_tight = abs(ctx.solution.sens.constraints.get(constraint, 0.0)) > 1e-5
@@ -632,9 +652,10 @@ def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
         node = _process_term(top_vk, term, ctx, remaining_depth=remaining_depth)
         node.fraction = term.term_val / total_val if total_val else 0.0
         nodes.append(node)
+    slack_frac = 0.0
     if not is_tight and total_val:
-        slack_frac = 1.0 - sum(n.fraction for n in nodes) - peeled_frac
-        if abs(slack_frac) > 1e-4:
+        slack_frac = max(0.0, 1.0 - sum(n.fraction for n in nodes) - peeled_frac)
+        if slack_frac > 1e-4:
             nodes.append(
                 BudgetNode(
                     label="[slack]",
@@ -645,7 +666,13 @@ def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
                     units=ctx.level_units,
                 )
             )
-    return nodes, peeled_frac
+        else:
+            slack_frac = 0.0
+    if remaining_depth > 0 and _is_redundant_leaf(nodes, peeled_frac):
+        # Single-monomial leaf: the lone child just duplicates the parent.
+        # Skip when the user truncated by depth (remaining_depth == 0).
+        return [], peeled_frac, slack_frac
+    return nodes, peeled_frac, slack_frac
 
 
 def _compute_cbe_ga(node):
@@ -722,10 +749,13 @@ def build_budget(  # pylint: disable=too-many-locals
             f"'{top_vk.name}' as the sole term on the greater-than side."
         )
     if len(matches) > 1:
-        warnings.warn(
-            f"Multiple budget constraints found for {top_vk}; "
-            "using highest-sensitivity one.",
-            stacklevel=2,
+        matches = _drop_nonbinding(matches)
+    if len(matches) > 1:
+        rhs_list = "\n  ".join(str(m[1]) for m in matches)
+        raise ValueError(
+            f"Cannot build a budget for {top_vk}: multiple budget constraints "
+            f"are simultaneously tight (the decomposition is ambiguous). "
+            f"Right-hand sides:\n  {rhs_list}"
         )
 
     constraint, lt, _ = matches[0]
@@ -748,7 +778,7 @@ def build_budget(  # pylint: disable=too-many-locals
         level_units=display_units,
         visited=frozenset({top_vk}),
     )
-    children, peeled_frac = _build_children(
+    children, peeled_frac, _ = _build_children(
         top_vk, lt, constraint, ctx, remaining_depth=depth - 1
     )
     for child in children:

--- a/gpkit/budgets.py
+++ b/gpkit/budgets.py
@@ -543,6 +543,10 @@ def _attach_sub_budget(node, child_vk, ctx, remaining_depth=float("inf")):
     )
     node.has_growth = peeled_frac > 0
     node.slack = slack_frac
+    if not node.children and peeled_frac > 0:
+        # Suppression dropped the lone non-growth term; record this level's
+        # peeled growth so _compute_cbe_ga's leaf branch derives cbe correctly.
+        node.ga_value = node.value * peeled_frac
 
 
 def _process_term(top_vk, term, ctx, remaining_depth=float("inf")):
@@ -618,9 +622,9 @@ def _is_allowance_term(term, parent_vk):
     return vk.name == f"{parent_vk.name}_growth" and vk.lineage == parent_vk.lineage
 
 
-def _is_redundant_leaf(nodes, peeled_frac):
+def _is_redundant_leaf(nodes):
     "True when *nodes* is a single child that visually duplicates its parent."
-    if peeled_frac != 0.0 or len(nodes) != 1:
+    if len(nodes) != 1:
         return False
     only = nodes[0]
     return not only.children and not only.terminate and only.label != "[slack]"
@@ -668,7 +672,7 @@ def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
             )
         else:
             slack_frac = 0.0
-    if remaining_depth > 0 and _is_redundant_leaf(nodes, peeled_frac):
+    if remaining_depth > 0 and _is_redundant_leaf(nodes):
         # Single-monomial leaf: the lone child just duplicates the parent.
         # Skip when the user truncated by depth (remaining_depth == 0).
         return [], peeled_frac, slack_frac
@@ -676,7 +680,11 @@ def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
 
 
 def _compute_cbe_ga(node):
-    """Post-order: cbe = sum of leaf values; ga = value − cbe.
+    """Post-order cbe/ga split.
+
+    Non-leaves: ``cbe`` is the sum of children's cbe; ``ga`` is the
+    remainder.  Leaves: ``ga`` is pre-set when growth was peeled (zero
+    otherwise) and ``cbe`` is derived from it.
 
     Also propagates ``has_growth`` up: a node has growth if it owns a peeled
     allowance (set in _attach_sub_budget) or any descendant does.
@@ -686,9 +694,9 @@ def _compute_cbe_ga(node):
             _compute_cbe_ga(child)
         node.cbe_value = sum(c.cbe_value for c in node.children)
         node.has_growth = node.has_growth or any(c.has_growth for c in node.children)
+        node.ga_value = node.value - node.cbe_value
     else:
-        node.cbe_value = node.value
-    node.ga_value = node.value - node.cbe_value
+        node.cbe_value = node.value - node.ga_value
 
 
 def _resolve_vk(var):
@@ -783,7 +791,11 @@ def build_budget(  # pylint: disable=too-many-locals
     )
     for child in children:
         _compute_cbe_ga(child)
-    cbe_total = sum(c.cbe_value for c in children) if children else total_val
+    cbe_total = (
+        sum(c.cbe_value for c in children)
+        if children
+        else total_val * (1.0 - peeled_frac)
+    )
     has_growth = peeled_frac > 0 or any(c.has_growth for c in children)
     return Budget(
         top_vk=top_vk,

--- a/gpkit/budgets.py
+++ b/gpkit/budgets.py
@@ -225,9 +225,9 @@ class BudgetNode:  # pylint: disable=too-many-instance-attributes
     cbe_value: float = 0.0
     ga_value: float = 0.0
     has_growth: bool = False
-    # True when a sub-budget exists but expansion was deliberately stopped
-    # (e.g. multiple tight bounds on the same variable — ambiguous).
-    terminate: bool = False
+    # True when the term is a bare variable (e.g. ``m``); false for compound
+    # expressions (``rho*A``, ``1/m``, ``2*m``) that get suppressed when alone.
+    is_var: bool = False
 
 
 @dataclass
@@ -522,12 +522,8 @@ def _attach_sub_budget(node, child_vk, ctx, remaining_depth=float("inf")):
     sub_matches = find_budget_constraints(ctx.model, child_vk, ctx.solution)
     if len(sub_matches) > 1:
         sub_matches = _drop_nonbinding(sub_matches)
-    if not sub_matches:
-        return
-    if len(sub_matches) > 1:
-        # Multiple genuinely tight bounds — stop expansion. Mark the node so
-        # the caller doesn't treat its empty children as a redundant leaf.
-        node.terminate = True
+    if not sub_matches or len(sub_matches) > 1:
+        # No bound, or multiple genuinely tight bounds — leaf, stop expansion.
         return
     sub_c, sub_lt = sub_matches[0][0], sub_matches[0][1]
     child_units = child_vk.unitrepr if child_vk.unitrepr != "-" else "dimensionless"
@@ -543,73 +539,77 @@ def _attach_sub_budget(node, child_vk, ctx, remaining_depth=float("inf")):
     )
     node.has_growth = peeled_frac > 0
     node.slack = slack_frac
-    if not node.children and peeled_frac > 0:
-        # Suppression dropped the lone non-growth term; record this level's
-        # peeled growth so _compute_cbe_ga's leaf branch derives cbe correctly.
-        node.ga_value = node.value * peeled_frac
+
+
+def _term_is_var(term):
+    "True when *term* is a bare variable reference."
+    if term.ast_label is not None:
+        # AST tracked the term — trust its var/expression classification.
+        return term.is_var_node is True
+    if len(term.exp) != 1:
+        return False
+    (exp_value,) = term.exp.values()
+    return exp_value == 1 and abs(term.phys_coeff - 1.0) <= 1e-10
 
 
 def _process_term(top_vk, term, ctx, remaining_depth=float("inf")):
-    """Build a single BudgetNode for one term in a budget constraint's RHS."""
-    free_in_term = {vk for vk in term.exp if vk not in ctx.solution.constants}
+    """Build a single BudgetNode for one term in a budget constraint's RHS.
+
+    Bare-variable terms (``m``, ``m_min``) become recursable nodes — we try
+    to expand a sub-budget below them.  Compound terms (``rho*A``, ``1/m``,
+    ``2*m``) become non-recursing leaves; ``_is_redundant_leaf`` drops them
+    when they're the only child of their parent.
+    """
     parent_prefix = top_vk.lineagestr() if top_vk.lineage else None
-    is_simple = len(free_in_term) == 1 and term.exp.get(next(iter(free_in_term))) == 1
-    if is_simple:
-        child_vk = next(iter(free_in_term))
-        if term.ast_label is not None:
-            label = term.ast_label
-        else:
-            has_constants = any(vk in ctx.solution.constants for vk in term.exp)
-            if has_constants or abs(term.phys_coeff - 1.0) > 1e-10:
-                label = _format_term_label(
-                    term.exp, term.phys_coeff, strip_prefix=parent_prefix
-                )
-            else:
-                label = _vk_display(child_vk, lineage=True, strip_prefix=parent_prefix)
-        # Use the child variable's own declared units for per-row display
-        native_units = (
-            child_vk.unitrepr if child_vk.unitrepr != "-" else ctx.level_units
+    is_var = _term_is_var(term)
+    if not is_var:
+        label = (
+            term.ast_label
+            if term.ast_label is not None
+            else _format_term_label(
+                term.exp, term.phys_coeff, strip_prefix=parent_prefix
+            )
         )
-        if native_units != ctx.level_units and term.term_qty is not None:
-            try:
-                native_val = float(term.term_qty.to(native_units).magnitude)
-            except (DimensionalityError, AttributeError, TypeError, ValueError):
-                native_units = ctx.level_units
-                native_val = term.term_val
-        else:
-            native_units = ctx.level_units
-            native_val = term.term_val
-        node = BudgetNode(
+        return BudgetNode(
             label=label,
-            vk=child_vk,
-            value=native_val,
+            vk=None,
+            value=term.term_val,
             fraction=0.0,
             slack=0.0,
-            units=native_units,
+            units=ctx.level_units,
+            is_var=False,
         )
-        can_recurse = term.ast_label is None or term.is_var_node is True
-        if (
-            can_recurse
-            and child_vk not in ctx.visited
-            and child_vk.units is not None
-            and child_vk.units.is_compatible_with(ctx.level_units)
-            and remaining_depth > 0
-        ):
-            _attach_sub_budget(node, child_vk, ctx, remaining_depth=remaining_depth - 1)
-        return node
+    (child_vk,) = term.exp.keys()
     label = (
         term.ast_label
         if term.ast_label is not None
-        else _format_term_label(term.exp, term.phys_coeff, strip_prefix=parent_prefix)
+        else _vk_display(child_vk, lineage=True, strip_prefix=parent_prefix)
     )
-    return BudgetNode(
+    # Render in the variable's own declared units when they differ from
+    # the parent's level units.
+    units = child_vk.unitrepr if child_vk.unitrepr != "-" else ctx.level_units
+    if units != ctx.level_units and term.term_qty is not None:
+        val = float(term.term_qty.to(units).magnitude)
+    else:
+        units = ctx.level_units
+        val = term.term_val
+    node = BudgetNode(
         label=label,
-        vk=None,
-        value=term.term_val,
+        vk=child_vk,
+        value=val,
         fraction=0.0,
         slack=0.0,
-        units=ctx.level_units,
+        units=units,
+        is_var=True,
     )
+    if (
+        child_vk not in ctx.visited
+        and child_vk.units is not None
+        and child_vk.units.is_compatible_with(ctx.level_units)
+        and remaining_depth > 0
+    ):
+        _attach_sub_budget(node, child_vk, ctx, remaining_depth=remaining_depth - 1)
+    return node
 
 
 def _is_allowance_term(term, parent_vk):
@@ -622,12 +622,9 @@ def _is_allowance_term(term, parent_vk):
     return vk.name == f"{parent_vk.name}_growth" and vk.lineage == parent_vk.lineage
 
 
-def _is_redundant_leaf(nodes):
-    "True when *nodes* is a single child that visually duplicates its parent."
-    if len(nodes) != 1:
-        return False
-    only = nodes[0]
-    return not only.children and not only.terminate and only.label != "[slack]"
+def _is_monomial_leaf(nodes):
+    "True when *nodes* is a single compound (non-bare-var) row — drop it."
+    return len(nodes) == 1 and not nodes[0].is_var
 
 
 def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
@@ -672,19 +669,15 @@ def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
             )
         else:
             slack_frac = 0.0
-    if remaining_depth > 0 and _is_redundant_leaf(nodes):
-        # Single-monomial leaf: the lone child just duplicates the parent.
-        # Skip when the user truncated by depth (remaining_depth == 0).
+    if _is_monomial_leaf(nodes):
+        # Compound monomial expression as a lone child — visually redundant
+        # with the parent's value; drop it regardless of depth.
         return [], peeled_frac, slack_frac
     return nodes, peeled_frac, slack_frac
 
 
 def _compute_cbe_ga(node):
-    """Post-order cbe/ga split.
-
-    Non-leaves: ``cbe`` is the sum of children's cbe; ``ga`` is the
-    remainder.  Leaves: ``ga`` is pre-set when growth was peeled (zero
-    otherwise) and ``cbe`` is derived from it.
+    """Post-order: cbe = sum of leaf values; ga = value − cbe.
 
     Also propagates ``has_growth`` up: a node has growth if it owns a peeled
     allowance (set in _attach_sub_budget) or any descendant does.
@@ -694,9 +687,9 @@ def _compute_cbe_ga(node):
             _compute_cbe_ga(child)
         node.cbe_value = sum(c.cbe_value for c in node.children)
         node.has_growth = node.has_growth or any(c.has_growth for c in node.children)
-        node.ga_value = node.value - node.cbe_value
     else:
-        node.cbe_value = node.value - node.ga_value
+        node.cbe_value = node.value
+    node.ga_value = node.value - node.cbe_value
 
 
 def _resolve_vk(var):
@@ -791,11 +784,7 @@ def build_budget(  # pylint: disable=too-many-locals
     )
     for child in children:
         _compute_cbe_ga(child)
-    cbe_total = (
-        sum(c.cbe_value for c in children)
-        if children
-        else total_val * (1.0 - peeled_frac)
-    )
+    cbe_total = sum(c.cbe_value for c in children) if children else total_val
     has_growth = peeled_frac > 0 or any(c.has_growth for c in children)
     return Budget(
         top_vk=top_vk,

--- a/gpkit/budgets.py
+++ b/gpkit/budgets.py
@@ -225,6 +225,9 @@ class BudgetNode:  # pylint: disable=too-many-instance-attributes
     cbe_value: float = 0.0
     ga_value: float = 0.0
     has_growth: bool = False
+    # Fraction of *value* peeled off as a growth allowance at this level
+    # (excludes growth from descendants).  Drives the leaf cbe/ga split.
+    peeled_frac: float = 0.0
 
 
 @dataclass
@@ -531,16 +534,9 @@ def _attach_sub_budget(node, child_vk, ctx, remaining_depth=float("inf")):
         level_units=child_units,
         visited=ctx.visited | {child_vk},
     )
-    node.children, peeled_frac, slack_frac = _build_children(
+    node.children, node.peeled_frac, node.slack = _build_children(
         child_vk, sub_lt, sub_c, sub_ctx, remaining_depth=remaining_depth
     )
-    node.has_growth = peeled_frac > 0
-    node.slack = slack_frac
-    if not node.children and peeled_frac > 0:
-        # Suppression dropped the lone non-growth (compound) term; record
-        # this level's peeled growth so _compute_cbe_ga's leaf branch can
-        # derive cbe = value − ga correctly.
-        node.ga_value = node.value * peeled_frac
 
 
 def _process_term(top_vk, term, ctx, remaining_depth=float("inf")):
@@ -676,25 +672,26 @@ def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
     return nodes, peeled_frac, slack_frac
 
 
+def _cbe_value(value, children, peeled_frac):
+    "Sum children's cbe when present; otherwise scale value by non-growth fraction."
+    if children:
+        return sum(c.cbe_value for c in children)
+    return value * (1.0 - peeled_frac)
+
+
 def _compute_cbe_ga(node):
     """Post-order cbe/ga split.
 
-    Non-leaves: ``cbe`` is the sum of children's cbe; ``ga`` is the
-    remainder.  Leaves: ``ga_value`` is pre-set in ``_attach_sub_budget``
-    when growth was peeled but the lone non-growth term was suppressed
-    (zero otherwise); ``cbe`` is derived from it.
-
-    Also propagates ``has_growth`` up: a node has growth if it owns a peeled
-    allowance (set in _attach_sub_budget) or any descendant does.
+    For every node, ``ga = value − cbe``.  Non-leaves take ``cbe`` from the
+    sum of children's cbe; leaves derive it from their own ``peeled_frac``.
+    ``has_growth`` propagates up from peeled allowances at this level or in
+    any descendant.
     """
-    if node.children:
-        for child in node.children:
-            _compute_cbe_ga(child)
-        node.cbe_value = sum(c.cbe_value for c in node.children)
-        node.has_growth = node.has_growth or any(c.has_growth for c in node.children)
-        node.ga_value = node.value - node.cbe_value
-    else:
-        node.cbe_value = node.value - node.ga_value
+    for child in node.children:
+        _compute_cbe_ga(child)
+    node.cbe_value = _cbe_value(node.value, node.children, node.peeled_frac)
+    node.ga_value = node.value - node.cbe_value
+    node.has_growth = node.peeled_frac > 0 or any(c.has_growth for c in node.children)
 
 
 def _resolve_vk(var):
@@ -789,11 +786,7 @@ def build_budget(  # pylint: disable=too-many-locals
     )
     for child in children:
         _compute_cbe_ga(child)
-    cbe_total = (
-        sum(c.cbe_value for c in children)
-        if children
-        else total_val * (1.0 - peeled_frac)
-    )
+    cbe_total = _cbe_value(total_val, children, peeled_frac)
     has_growth = peeled_frac > 0 or any(c.has_growth for c in children)
     return Budget(
         top_vk=top_vk,

--- a/gpkit/tests/test_budgets.py
+++ b/gpkit/tests/test_budgets.py
@@ -448,6 +448,30 @@ class TestBudgetWithGrowth:
         for node in _walk_all_nodes(b.children):
             assert node.cbe_value + node.ga_value == pytest.approx(node.value, rel=1e-4)
 
+    def test_growth_leaf_suppresses_lone_term_at_top_level(self):
+        # GrowthSpar has m >= e + m_growth; once growth is peeled the lone
+        # non-growth term is redundant and gets suppressed.
+        model = GrowthSpar()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        assert b.children == []
+        assert b.cbe_total == pytest.approx(50.0, rel=1e-4)
+        assert b.ga_total == pytest.approx(10.0, rel=1e-4)
+        assert b.total == pytest.approx(60.0, rel=1e-4)
+
+    def test_growth_leaf_suppresses_lone_term_under_parent(self):
+        # GrowthWing has spar1, spar2 each with their own growth + 'e' leaf.
+        # The 'e' grandchildren are suppressed; cbe/ga still split correctly.
+        model = GrowthWing()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        # Wing has two children (spar1, spar2), no grandchildren.
+        assert len(b.children) == 2
+        for spar_node in b.children:
+            assert spar_node.children == []
+            assert spar_node.cbe_value == pytest.approx(50.0, rel=1e-4)
+            assert spar_node.ga_value == pytest.approx(10.0, rel=1e-4)
+
     def test_mixed_growth_and_plain_children(self):
         model = GrowthMixedWing()
         sol, _ = solve(model)
@@ -504,20 +528,13 @@ class TestBudgetRenderingWithGrowth:
 class TestBudgetGrowthCellBlanking:
     """GA cell renders blank for rows with no growth in their subtree."""
 
-    def test_leaf_row_in_growth_subtree_has_blank_ga(self):
+    def test_growth_leaf_has_no_redundant_e_row(self):
+        # The lone non-growth term ('e') is redundant with the parent's CBE
+        # column and gets suppressed.
         model = GrowthSpar()
         sol, _ = solve(model)
         out = build_budget(sol, model, model.m).text()
-        # Row for the leaf 'e' should NOT contain a numeric Growth value
-        # ("0", "0.0", "1e-08", etc). Find the e-row and check its GA col.
-        e_line = next(
-            line for line in out.splitlines() if line.lstrip().startswith("e ")
-        )
-        # Three numeric columns: Nominal, Growth, Total. Growth should be blank.
-        # Split-from-the-right since the Total/Units/Frac suffix is fixed.
-        tokens = e_line.split()
-        # Tokens: ['e', nominal, total, '[kg]', pct]  (no growth token)
-        assert tokens == ["e", "50", "50", "[kg]", "83.3%"]
+        assert not any(line.lstrip().startswith("e ") for line in out.splitlines())
 
     def test_non_growth_submodel_has_blank_ga_despite_noise(self):
         model = GrowthMixedWing()
@@ -553,13 +570,13 @@ class TestBudgetGrowthCellBlanking:
         assert "10" in tokens
 
     def test_has_growth_propagates_in_to_dict(self):
+        # Growth-bearing top with a single non-growth term: child row is
+        # suppressed but has_growth is still surfaced at the top.
         model = GrowthSpar()
         sol, _ = solve(model)
         d = build_budget(sol, model, model.m).to_dict()
         assert d["has_growth"] is True
-        # Find the leaf 'e' child — it should have has_growth False
-        e_child = next(c for c in d["children"] if c["label"] == "e")
-        assert e_child["has_growth"] is False
+        assert d["children"] == []
 
 
 def _walk_all_nodes(nodes):

--- a/gpkit/tests/test_budgets.py
+++ b/gpkit/tests/test_budgets.py
@@ -343,7 +343,7 @@ class TestBudgetErrors:
         model = Inner()
         sol, _ = solve(model)
         b = build_budget(sol, model, model.m)
-        assert b.children == []
+        assert not b.children
 
     def test_multi_term_posynomial_keeps_children(self):
         # Wing.m >= Spar.m + Skin.m has two terms — both rows must stay.
@@ -495,7 +495,7 @@ class TestBudgetWithGrowth:
         assert b.cbe_total == pytest.approx(0.078, rel=1e-4)
         assert b.ga_total == pytest.approx(0.0156, rel=1e-4)
         # Compound term collapsed; no children rendered.
-        assert b.children == []
+        assert not b.children
 
     def test_mixed_growth_and_plain_children(self):
         model = GrowthMixedWing()

--- a/gpkit/tests/test_budgets.py
+++ b/gpkit/tests/test_budgets.py
@@ -1,8 +1,9 @@
 """Tests for gpkit.budgets — variable budget computation and display."""
 
-# pylint: disable=attribute-defined-outside-init
+# pylint: disable=attribute-defined-outside-init,too-many-lines
 
 import math
+import warnings
 
 import pytest
 
@@ -317,12 +318,29 @@ class TestBudgetErrors:
             build_budget(sol, model, "m")
 
     def test_spar_budget_leaf(self):
+        # Spar.m >= m_min is a single-monomial RHS — no decomposition row
         model = Aircraft()
         sol, _ = solve(model)
-        # Spar.m's budget terminates at a constant — no named-variable children
         b = build_budget(sol, model, model.wing.spar.m)
-        named_children = [n for n in b.children if n.vk is not None]
-        assert len(named_children) == 0
+        assert not b.children
+
+    def test_single_monomial_leaf_suppressed_under_aircraft(self):
+        # Aircraft.m -> Wing.m -> {Spar.m, Skin.m}; each leaf has m >= m_min
+        # (single monomial). Those leaves should render with no further children.
+        model = Aircraft()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        wing_node = b.children[0]
+        for leaf in wing_node.children:
+            assert leaf.children == []
+
+    def test_multi_term_posynomial_keeps_children(self):
+        # Wing.m >= Spar.m + Skin.m has two terms — both rows must stay.
+        model = Aircraft()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        wing_node = b.children[0]
+        assert len(wing_node.children) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -653,20 +671,13 @@ class TestBuildBudgetMixedUnits:
         b = sol.budget(model.m)
         assert isinstance(b, Budget)
 
-    def test_label_includes_constants(self):
-        # m >= rho*V: child label should show "rho·V", not just "V"
-        model = Cylinder()
-        sol, _ = solve(model)
-        b = build_budget(sol, model, model.m)
-        assert any("rho" in c.label for c in b.children)
-
     def test_no_cross_unit_recursion(self):
-        # rho·V contributes to m, but V (m^3) != m (kg): should not recurse into V
+        # m >= rho*V is a single-monomial RHS; V also has different units
+        # so no recursion is possible. Result: budget renders with no children.
         model = Cylinder()
         sol, _ = solve(model)
         b = build_budget(sol, model, model.m)
-        rho_v_node = b.children[0]
-        assert rho_v_node.children == []
+        assert not b.children
 
 
 # ---------------------------------------------------------------------------
@@ -953,20 +964,140 @@ class ScaledTermModel(Model):
 
 
 class TestScaledTermNoRecursion:
-    """Scaled terms (f * m_sub) must be leaf nodes, not recursed into."""
+    """Scaled-term leaves (f * m_sub) collapse — single-monomial RHS suppressed"""
 
-    def test_scaled_node_has_no_children(self):
+    def test_scaled_term_leaf_has_no_children(self):
+        # m >= 0.5 * m_sub is a single monomial with a scaled simple term;
+        # the row is redundant with the parent total, so no child is rendered.
         model = ScaledTermModel()
         sol, _ = solve(model)
         b = build_budget(sol, model, model.m)
+        assert not b.children
+
+    def test_scaled_term_total_correct(self):
+        """Top total reflects 0.5 * 10 = 5 kg, even with no child row."""
+        model = ScaledTermModel()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        assert b.total == pytest.approx(5.0, rel=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Tests: multiple budget constraints (issue #185)
+# ---------------------------------------------------------------------------
+
+
+class TightAndSlackBoundsOnSub(Model):
+    """Sub-variable has one tight bound (rollup) and one slack bound (floor).
+
+    The slack bound has near-zero sensitivity at the optimum and should be
+    filtered out — leaving the rollup as the unique budget constraint.
+    """
+
+    spar: Spar
+    skin: Skin
+    m: Variable
+
+    def setup(self):
+        self.spar = Spar()
+        self.skin = Skin()
+        self.m = Variable("m", "kg", "wing mass")
+        self.cost = self.m
+        slack_floor = Variable("m_floor", 1, "kg", "non-binding floor")
+        return [
+            self.m >= self.spar.m + self.skin.m,  # tight rollup, m = 15
+            self.m >= slack_floor,  # slack at optimum, sens ≈ 0
+            self.spar,
+            self.skin,
+        ]
+
+
+class TwoTightBoundsOnSub(Model):
+    """Sub-variable with two distinct lower bounds, both equal at the optimum.
+
+    Real-world cases (e.g. propellant mass with a physics rollup AND a tank
+    minimum-fill bound) can produce non-trivial dual splits across both
+    constraints. Conic solvers usually collapse the dual onto one when the
+    constraints are exact duplicates, so the tests below patch the sens
+    dict to simulate the genuinely-ambiguous case.
+    """
+
+    m: Variable
+
+    def setup(self):
+        a = Variable("a", 5, "kg")
+        b = Variable("b", 5, "kg")
+        c = Variable("c", 10, "kg")
+        self.m = Variable("m", "kg", "ambiguous mass")
+        self.cost = self.m
+        return [
+            self.m >= a + b,
+            self.m >= c,
+        ]
+
+
+def _force_both_tight(sol, model, m_var):
+    """Patch the solution so both budget constraints on m have sens > threshold."""
+    matches = find_budget_constraints(model, m_var.key, sol)
+    assert len(matches) == 2, "fixture must have exactly two matches"
+    for c, _, _ in matches:
+        sol.sens.constraints[c] = 0.5
+
+
+class TestMultipleBudgetConstraints:
+    """Tests for ambiguity handling and near-zero sensitivity filtering."""
+
+    def test_no_warning_for_tight_plus_slack_at_top_level(self):
+        # Slack-bound noise must not raise a warning at the top level.
+        model = TightAndSlackBoundsOnSub()
+        sol, _ = solve(model)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            build_budget(sol, model, model.m)
+
+    def test_no_warning_for_tight_plus_slack_at_sub_budget(self):
+        # Same model exercised through a parent so it lands in _attach_sub_budget.
+        class Outer(Model):  # pylint: disable=missing-class-docstring
+            inner: TightAndSlackBoundsOnSub
+            m: Variable
+
+            def setup(self):  # pylint: disable=attribute-defined-outside-init
+                self.inner = TightAndSlackBoundsOnSub()
+                self.m = Variable("m", "kg")
+                self.cost = self.m
+                return [self.m >= self.inner.m, self.inner]
+
+        model = Outer()
+        sol, _ = solve(model)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            build_budget(sol, model, model.m)
+
+    def test_sub_budget_ambiguity_silent_leaf(self):
+        # Sub-variable with two genuinely tight bounds: leaf with no children.
+        class Outer(Model):  # pylint: disable=missing-class-docstring
+            sub: TwoTightBoundsOnSub
+            m: Variable
+
+            def setup(self):  # pylint: disable=attribute-defined-outside-init
+                self.sub = TwoTightBoundsOnSub()
+                self.m = Variable("m", "kg")
+                self.cost = self.m
+                return [self.m >= self.sub.m, self.sub]
+
+        model = Outer()
+        sol, _ = solve(model)
+        _force_both_tight(sol, model, model.sub.m)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            b = build_budget(sol, model, model.m)
         assert len(b.children) == 1
-        scaled_node = b.children[0]
-        assert scaled_node.children == []
+        assert not b.children[0].children
 
-    def test_scaled_node_value_correct(self):
-        """Node value is 0.5 * 10 = 5 kg, not 10 kg."""
-        model = ScaledTermModel()
+    def test_top_level_ambiguity_raises(self):
+        # User explicitly asked for a budget on the ambiguous variable.
+        model = TwoTightBoundsOnSub()
         sol, _ = solve(model)
-        b = build_budget(sol, model, model.m)
-        scaled_node = b.children[0]
-        assert scaled_node.value == pytest.approx(5.0, rel=1e-4)
+        _force_both_tight(sol, model, model.m)
+        with pytest.raises(ValueError, match="multiple"):
+            build_budget(sol, model, model.m)

--- a/gpkit/tests/test_budgets.py
+++ b/gpkit/tests/test_budgets.py
@@ -318,21 +318,32 @@ class TestBudgetErrors:
             build_budget(sol, model, "m")
 
     def test_spar_budget_leaf(self):
-        # Spar.m >= m_min is a single-monomial RHS — no decomposition row
+        # Spar.m >= m_min: m_min is a bare variable, kept as a child row.
         model = Aircraft()
         sol, _ = solve(model)
         b = build_budget(sol, model, model.wing.spar.m)
-        assert not b.children
+        assert any("m_min" in c.label for c in b.children)
 
-    def test_single_monomial_leaf_suppressed_under_aircraft(self):
-        # Aircraft.m -> Wing.m -> {Spar.m, Skin.m}; each leaf has m >= m_min
-        # (single monomial). Those leaves should render with no further children.
-        model = Aircraft()
+    def test_compound_leaf_suppressed_when_alone(self):
+        # Compound monomial expressions (multiple variables, like rho*A*L)
+        # are dropped when they're the only child of their parent.
+        class Inner(Model):
+            """Mass equals a 3-variable compound monomial expression."""
+
+            m: Variable
+
+            def setup(self):  # pylint: disable=attribute-defined-outside-init
+                rho = Variable("rho", 7800, "kg/m^3")
+                length = Variable("L", 0.1, "m")
+                area = Variable("A", 1e-4, "m^2")
+                self.m = Variable("m", "kg")
+                self.cost = self.m
+                return [self.m >= rho * length * area]
+
+        model = Inner()
         sol, _ = solve(model)
         b = build_budget(sol, model, model.m)
-        wing_node = b.children[0]
-        for leaf in wing_node.children:
-            assert leaf.children == []
+        assert b.children == []
 
     def test_multi_term_posynomial_keeps_children(self):
         # Wing.m >= Spar.m + Skin.m has two terms — both rows must stay.
@@ -448,29 +459,15 @@ class TestBudgetWithGrowth:
         for node in _walk_all_nodes(b.children):
             assert node.cbe_value + node.ga_value == pytest.approx(node.value, rel=1e-4)
 
-    def test_growth_leaf_suppresses_lone_term_at_top_level(self):
-        # GrowthSpar has m >= e + m_growth; once growth is peeled the lone
-        # non-growth term is redundant and gets suppressed.
+    def test_growth_leaf_keeps_named_var(self):
+        # GrowthSpar has m >= e + m_growth; e is a bare variable so its row
+        # is kept (the user named it for a reason).
         model = GrowthSpar()
         sol, _ = solve(model)
         b = build_budget(sol, model, model.m)
-        assert b.children == []
+        assert any(c.label == "e" for c in b.children)
         assert b.cbe_total == pytest.approx(50.0, rel=1e-4)
         assert b.ga_total == pytest.approx(10.0, rel=1e-4)
-        assert b.total == pytest.approx(60.0, rel=1e-4)
-
-    def test_growth_leaf_suppresses_lone_term_under_parent(self):
-        # GrowthWing has spar1, spar2 each with their own growth + 'e' leaf.
-        # The 'e' grandchildren are suppressed; cbe/ga still split correctly.
-        model = GrowthWing()
-        sol, _ = solve(model)
-        b = build_budget(sol, model, model.m)
-        # Wing has two children (spar1, spar2), no grandchildren.
-        assert len(b.children) == 2
-        for spar_node in b.children:
-            assert spar_node.children == []
-            assert spar_node.cbe_value == pytest.approx(50.0, rel=1e-4)
-            assert spar_node.ga_value == pytest.approx(10.0, rel=1e-4)
 
     def test_mixed_growth_and_plain_children(self):
         model = GrowthMixedWing()
@@ -528,13 +525,17 @@ class TestBudgetRenderingWithGrowth:
 class TestBudgetGrowthCellBlanking:
     """GA cell renders blank for rows with no growth in their subtree."""
 
-    def test_growth_leaf_has_no_redundant_e_row(self):
-        # The lone non-growth term ('e') is redundant with the parent's CBE
-        # column and gets suppressed.
+    def test_leaf_row_in_growth_subtree_has_blank_ga(self):
+        # The 'e' row (bare named variable) is rendered; its Growth column
+        # should be blank because e itself has no growth allowance.
         model = GrowthSpar()
         sol, _ = solve(model)
         out = build_budget(sol, model, model.m).text()
-        assert not any(line.lstrip().startswith("e ") for line in out.splitlines())
+        e_line = next(
+            line for line in out.splitlines() if line.lstrip().startswith("e ")
+        )
+        tokens = e_line.split()
+        assert tokens == ["e", "50", "50", "[kg]", "83.3%"]
 
     def test_non_growth_submodel_has_blank_ga_despite_noise(self):
         model = GrowthMixedWing()
@@ -570,13 +571,13 @@ class TestBudgetGrowthCellBlanking:
         assert "10" in tokens
 
     def test_has_growth_propagates_in_to_dict(self):
-        # Growth-bearing top with a single non-growth term: child row is
-        # suppressed but has_growth is still surfaced at the top.
         model = GrowthSpar()
         sol, _ = solve(model)
         d = build_budget(sol, model, model.m).to_dict()
         assert d["has_growth"] is True
-        assert d["children"] == []
+        # The leaf 'e' child has no growth of its own.
+        e_child = next(c for c in d["children"] if c["label"] == "e")
+        assert e_child["has_growth"] is False
 
 
 def _walk_all_nodes(nodes):
@@ -716,22 +717,26 @@ class MixedUnitCoeffModel(Model):
 class TestMixedUnitCoeff:
     """Values must be correct when unit conversion is baked into hmap coefficient."""
 
-    def test_children_sum_to_total(self):
+    def test_total_in_kg(self):
+        # Top total is in the parent's level units (kg) regardless of how
+        # children are rendered.
         model = MixedUnitCoeffModel()
         sol, _ = solve(model)
         b = build_budget(sol, model, model.m)
-        child_sum = sum(n.value for n in b.children)
-        assert abs(child_sum - b.total) / b.total < 1e-4
+        # 1 lb (≈ 0.4536 kg) + 1 kg ≈ 1.4536 kg total
+        assert b.total == pytest.approx(1.45359237, rel=1e-4)
 
-    def test_component_values_correct(self):
-        """m_a ≈ 0.4536 kg, m_b = 1.0 kg."""
+    def test_component_values_in_native_units(self):
+        # Each child renders in its declared units: m_a in lbs, m_b in kg.
         model = MixedUnitCoeffModel()
         sol, _ = solve(model)
         b = build_budget(sol, model, model.m)
-        m_b_node = next(n for n in b.children if "m_b" in n.label)
-        assert m_b_node.value == pytest.approx(1.0, rel=1e-4)
         m_a_node = next(n for n in b.children if "m_a" in n.label)
-        assert m_a_node.value == pytest.approx(0.45359237, rel=1e-4)
+        assert m_a_node.units == "lbs"
+        assert m_a_node.value == pytest.approx(1.0, rel=1e-4)
+        m_b_node = next(n for n in b.children if "m_b" in n.label)
+        assert m_b_node.units == "kg"
+        assert m_b_node.value == pytest.approx(1.0, rel=1e-4)
 
     def test_labels_show_physical_coeff(self):
         """Pure unit-conversion terms should NOT show a numeric coefficient."""
@@ -903,6 +908,43 @@ class TestBudgetDepth:
         b_inf = build_budget(sol, model, model.m, depth=math.inf)
         assert len(b_default.children) == len(b_inf.children)
         assert len(b_default.children[0].children) == len(b_inf.children[0].children)
+
+    def test_compound_leaf_dropped_at_depth_boundary(self):
+        # Compound monomial expressions (rho*A*L) must be suppressed even
+        # when they happen to land at the depth boundary the user picked.
+        class Inner(Model):
+            """Mass equals a 3-variable compound monomial expression."""
+
+            m: Variable
+
+            def setup(self):  # pylint: disable=attribute-defined-outside-init
+                rho = Variable("rho", 7800, "kg/m^3")
+                length = Variable("L", 0.1, "m")
+                area = Variable("A", 1e-4, "m^2")
+                self.m = Variable("m", "kg")
+                self.cost = self.m
+                return [self.m >= rho * length * area]
+
+        class Outer(Model):
+            """Wraps Inner with a single-monomial relay constraint."""
+
+            inner: Inner
+            m: Variable
+
+            def setup(self):  # pylint: disable=attribute-defined-outside-init
+                self.inner = Inner()
+                self.m = Variable("m", "kg")
+                self.cost = self.m
+                return [self.m >= self.inner.m, self.inner]
+
+        model = Outer()
+        sol = model.solve(verbosity=0)
+        # depth=2 traverses Outer -> Inner -> rho*L*A; the compound
+        # grandchild row should be dropped, leaving Inner.m as a leaf.
+        b = build_budget(sol, model, model.m, depth=2)
+        inner_node = b.children[0]
+        assert "Inner.m" in inner_node.label
+        assert inner_node.children == []
 
     def test_solution_budget_depth_kwarg(self):
         """Solution.budget() accepts and respects depth=."""

--- a/gpkit/tests/test_budgets.py
+++ b/gpkit/tests/test_budgets.py
@@ -469,6 +469,34 @@ class TestBudgetWithGrowth:
         assert b.cbe_total == pytest.approx(50.0, rel=1e-4)
         assert b.ga_total == pytest.approx(10.0, rel=1e-4)
 
+    def test_growth_with_compound_rollup_keeps_cbe_ga_split(self):
+        # When the rollup is compound (rho*A*L), the lone non-growth term
+        # is dropped — but the parent's cbe/ga split must still match
+        # value/(1+growth) and value*growth/(1+growth) respectively.
+        class GrowthCompoundExpr(Model):
+            """Mass with growth declared on a compound rollup expression."""
+
+            m: Variable
+
+            def setup(self):  # pylint: disable=attribute-defined-outside-init
+                rho = Variable("rho", 7800, "kg/m^3")
+                length = Variable("L", 0.1, "m")
+                area = Variable("A", 1e-4, "m^2")
+                self.m = Variable("m", "kg", growth=0.20)
+                self.cost = self.m
+                return self.m.grown_from(rho * length * area)
+
+        model = GrowthCompoundExpr()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        # rho * L * A = 7800 * 0.1 * 1e-4 = 0.078 kg.
+        # m = 0.078 * 1.20 = 0.0936 kg; cbe = 0.078; ga = 0.0156.
+        assert b.total == pytest.approx(0.0936, rel=1e-4)
+        assert b.cbe_total == pytest.approx(0.078, rel=1e-4)
+        assert b.ga_total == pytest.approx(0.0156, rel=1e-4)
+        # Compound term collapsed; no children rendered.
+        assert b.children == []
+
     def test_mixed_growth_and_plain_children(self):
         model = GrowthMixedWing()
         sol, _ = solve(model)


### PR DESCRIPTION
## Summary

Two related cleanups to budget rendering:

1. **Suppress redundant single-monomial leaf rows.** When a sub-budget's RHS is a single monomial (e.g. `Spar.m >= rho*A*t` or `Spar.m >= m_min`), the printout previously emitted a child row that just duplicated the parent at 100%. That row is dropped now. Multi-term posynomials (`m >= a + b`) still render each term — those are real decomposition.
2. **Fix #185 — handle multiple budget constraints sensibly.** `find_budget_constraints` previously returned all matches; callers silently picked the highest-sensitivity one and warned every time. Now:
   - When >1 match exists, near-zero sensitivities (`<1e-5`) are dropped as non-binding noise (e.g. propellant mass with both a physics rollup and a slack tank-fill bound). Silent.
   - If multiple genuinely tight bounds remain, the recursion stops rather than fabricating a hierarchy: in `_attach_sub_budget` the node becomes a leaf (silent, marked via a new `terminate` flag so it isn't suppressed by rule 1); in `build_budget` (top-level, user explicitly asked) we raise `ValueError` listing the ambiguous RHSs.

`_build_children` now returns a 3-tuple `(nodes, peeled_frac, slack_frac)` so `_attach_sub_budget` reads slack directly instead of reverse-engineering it from child fractions. The `warnings` import is gone — this module no longer warns.

Before / after on the existing Aircraft fixture:

```
Budget  —  Aircraft.m              Budget  —  Aircraft.m
---------------------              ---------------------
  Aircraft.m  15  [kg]  100.0%       Aircraft.m  15  [kg]  100.0%
    Wing.m    15  [kg]  100.0%         Wing.m    15  [kg]  100.0%
      Skin.m   5  [kg]   33.3%           Skin.m   5  [kg]   33.3%
        m_min  5  [kg]  100.0%   <-      Spar.m  10  [kg]   66.7%
      Spar.m  10  [kg]   66.7%
        m_min 10  [kg]  100.0%   <-
```

## Test plan

- [x] `uv run pytest gpkit/tests/` — 765 passed, 3 skipped
- [x] `make pylint` — 10.00/10
- [x] New tests for: single-monomial leaf suppression at top and nested levels, multi-term posynomials still render both terms, depth-truncated leaves are NOT suppressed, no warning for tight+slack bounds, ambiguous bounds produce a silent leaf at sub-budget level and a `ValueError` at top level (sens dict patched to simulate the rare genuine-ambiguity case the GP solver typically collapses)
- [x] Visual check of rendered Aircraft budget — redundant `m_min` rows gone, Wing decomposition intact

Closes #185.