### PR TITLE
Fix bug: depth-limited budget roll-up

### DIFF
--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -1,6 +1,6 @@
 "GP and SP modeling package"
 
-__version__ = "0.3.6"
+__version__ = "0.3.7"
 
 import numpy as _np
 

--- a/gpkit/budgets.py
+++ b/gpkit/budgets.py
@@ -517,7 +517,7 @@ def _make_term(mon, hmap_units, ast_labels, ast_is_var, ctx):
     )
 
 
-def _attach_sub_budget(node, child_vk, ctx, remaining_depth=float("inf")):
+def _attach_sub_budget(node, child_vk, ctx):
     "Recursively attach sub-budget children to *node* if a budget constraint exists."
     sub_matches = find_budget_constraints(ctx.model, child_vk, ctx.solution)
     if len(sub_matches) > 1:
@@ -535,11 +535,11 @@ def _attach_sub_budget(node, child_vk, ctx, remaining_depth=float("inf")):
         visited=ctx.visited | {child_vk},
     )
     node.children, node.peeled_frac, node.slack = _build_children(
-        child_vk, sub_lt, sub_c, sub_ctx, remaining_depth=remaining_depth
+        child_vk, sub_lt, sub_c, sub_ctx
     )
 
 
-def _process_term(top_vk, term, ctx, remaining_depth=float("inf")):
+def _process_term(top_vk, term, ctx):
     """Build a single BudgetNode for one term in a budget constraint's RHS.
 
     Bare-variable terms (``m``, ``m_min``) become recursable nodes — we try
@@ -591,9 +591,8 @@ def _process_term(top_vk, term, ctx, remaining_depth=float("inf")):
         child_vk not in ctx.visited
         and child_vk.units is not None
         and child_vk.units.is_compatible_with(ctx.level_units)
-        and remaining_depth > 0
     ):
-        _attach_sub_budget(node, child_vk, ctx, remaining_depth=remaining_depth - 1)
+        _attach_sub_budget(node, child_vk, ctx)
     return node
 
 
@@ -623,7 +622,7 @@ def _is_redundant_compound_leaf(nodes):
     return len(nodes) == 1 and nodes[0].vk is None
 
 
-def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
+def _build_children(top_vk, lt, constraint, ctx):
     """Recursively build BudgetNode children from the lt side of a budget constraint.
 
     When *top_vk* declares a growth allowance, the auto-generated allowance
@@ -646,7 +645,7 @@ def _build_children(top_vk, lt, constraint, ctx, remaining_depth=float("inf")):
         if _is_allowance_term(term, top_vk):
             peeled_frac += term.term_val / total_val if total_val else 0.0
             continue
-        node = _process_term(top_vk, term, ctx, remaining_depth=remaining_depth)
+        node = _process_term(top_vk, term, ctx)
         node.fraction = term.term_val / total_val if total_val else 0.0
         nodes.append(node)
     slack_frac = 0.0
@@ -706,6 +705,16 @@ def _resolve_vk(var):
     )
 
 
+def _trim_to_depth(nodes, remaining_depth):
+    "Remove children beyond *remaining_depth* levels; cbe/ga values are unchanged."
+    if remaining_depth <= 0:
+        for node in nodes:
+            node.children = []
+        return
+    for node in nodes:
+        _trim_to_depth(node.children, remaining_depth - 1)
+
+
 def build_budget(  # pylint: disable=too-many-locals
     solution, model, var, display_units=None, depth=float("inf")
 ):
@@ -722,9 +731,10 @@ def build_budget(  # pylint: disable=too-many-locals
     display_units : str, optional
         Units for all displayed values.  Defaults to the variable's own units.
     depth : int or float, optional
-        Maximum expansion depth. ``depth=0`` returns only the top variable with
-        no children. ``depth=1`` expands one level. Defaults to ``float('inf')``
-        (fully recursive, current behaviour).
+        Maximum display depth. ``depth=0`` returns only the top variable with
+        no children. ``depth=1`` shows one level of children. Defaults to
+        ``float('inf')`` (fully recursive). Growth allowances and cbe/ga totals
+        are always computed from the full tree regardless of *depth*.
 
     Returns
     -------
@@ -781,13 +791,12 @@ def build_budget(  # pylint: disable=too-many-locals
         level_units=display_units,
         visited=frozenset({top_vk}),
     )
-    children, peeled_frac, _ = _build_children(
-        top_vk, lt, constraint, ctx, remaining_depth=depth - 1
-    )
+    children, peeled_frac, _ = _build_children(top_vk, lt, constraint, ctx)
     for child in children:
         _compute_cbe_ga(child)
     cbe_total = _cbe_value(total_val, children, peeled_frac)
     has_growth = peeled_frac > 0 or any(c.has_growth for c in children)
+    _trim_to_depth(children, depth - 1)
     return Budget(
         top_vk=top_vk,
         total=total_val,

--- a/gpkit/tests/test_budgets.py
+++ b/gpkit/tests/test_budgets.py
@@ -421,6 +421,43 @@ class GrowthMixedWing(Model):
         ]
 
 
+class BareParentGrowthChild(Model):
+    """Bare (no-growth) parent with one growth child and one plain child."""
+
+    spar: GrowthSpar
+    skin: GrowthSkin
+    m: Variable
+
+    def setup(self):
+        self.spar = GrowthSpar()  # m with growth=0.20, e=50 → m=60
+        self.skin = GrowthSkin()  # m with no growth, e=30 → m=30
+        self.m = Variable("m", "kg", "total mass")  # NO growth declared
+        self.cost = self.m
+        return [
+            self.m >= self.spar.m + self.skin.m,  # bare constraint, no grown_from
+            self.spar,
+            self.skin,
+        ]
+
+
+class BareGrandparentGrowthGrandchild(Model):
+    """Two levels of bare (no-growth) parents; growth only in the grandchild."""
+
+    wing: BareParentGrowthChild
+    m: Variable
+
+    def setup(self):
+        self.wing = BareParentGrowthChild()  # bare parent with growth grandchild
+        skin2 = GrowthSkin()  # no growth, e=30
+        self.m = Variable("m", "kg", "aircraft mass")  # NO growth
+        self.cost = self.m
+        return [
+            self.m >= self.wing.m + skin2.m,  # bare, no growth
+            self.wing,
+            skin2,
+        ]
+
+
 class TestBudgetWithGrowth:
     """Budget walker peels off allowance terms and computes Nominal/Growth columns."""
 
@@ -613,6 +650,81 @@ def _walk_all_nodes(nodes):
     for n in nodes:
         yield n
         yield from _walk_all_nodes(n.children)
+
+
+# ---------------------------------------------------------------------------
+# Tests: bare parent (no growth) with growth child
+# ---------------------------------------------------------------------------
+
+
+class TestBareParentWithGrowthChild:
+    """Budget correctly propagates growth through bare (no grown_from) parents."""
+
+    def test_budget_has_growth_true(self):
+        # Budget.has_growth must be True even though the top var declares no growth
+        model = BareParentGrowthChild()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        assert b.has_growth is True
+
+    def test_cbe_and_ga_totals(self):
+        # ga_total should equal the leaf's 10 kg growth; cbe = 80; total = 90
+        model = BareParentGrowthChild()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        assert b.total == pytest.approx(90.0, rel=1e-4)
+        assert b.cbe_total == pytest.approx(80.0, rel=1e-4)
+        assert b.ga_total == pytest.approx(10.0, rel=1e-4)
+
+    def test_growth_child_node_has_growth_true(self):
+        model = BareParentGrowthChild()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        spar_node = next(n for n in b.children if n.vk and "Spar" in n.vk.lineagestr())
+        assert spar_node.has_growth is True
+        assert spar_node.ga_value == pytest.approx(10.0, rel=1e-4)
+
+    def test_plain_child_node_has_growth_false(self):
+        model = BareParentGrowthChild()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        skin_node = next(n for n in b.children if n.vk and "Skin" in n.vk.lineagestr())
+        assert skin_node.has_growth is False
+
+    def test_growth_columns_rendered_in_text(self):
+        model = BareParentGrowthChild()
+        sol, _ = solve(model)
+        out = build_budget(sol, model, model.m).text()
+        assert "Nominal" in out
+        assert "Growth" in out
+
+    def test_invariant_at_every_node(self):
+        model = BareParentGrowthChild()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        for node in _walk_all_nodes(b.children):
+            assert node.cbe_value + node.ga_value == pytest.approx(node.value, rel=1e-4)
+
+    def test_three_level_bare_grandparent_growth_propagates(self):
+        # Two levels of bare parents above leaf; growth must bubble all the way up.
+        # aircraft.m (no growth) >= wing.m (no growth) + skin2.m (no growth)
+        # wing.m (no growth) >= spar.m (growth=0.20) + skin.m (no growth)
+        # spar: e=50 → m=60 (10 growth); skin: 30; wing.m=90; skin2=30; aircraft.m=120
+        # cbe: spar_cbe=50, skin_cbe=30, wing_cbe=80, skin2_cbe=30, total_cbe=110; ga=10
+        model = BareGrandparentGrowthGrandchild()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        assert b.has_growth is True
+        assert b.total == pytest.approx(120.0, rel=1e-4)
+        assert b.cbe_total == pytest.approx(110.0, rel=1e-4)
+        assert b.ga_total == pytest.approx(10.0, rel=1e-4)
+
+    def test_three_level_all_nodes_invariant(self):
+        model = BareGrandparentGrowthGrandchild()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m)
+        for node in _walk_all_nodes(b.children):
+            assert node.cbe_value + node.ga_value == pytest.approx(node.value, rel=1e-4)
 
 
 # ---------------------------------------------------------------------------
@@ -981,6 +1093,20 @@ class TestBudgetDepth:
         b = sol.budget(model.m, depth=1)
         assert len(b.children) == 1
         assert not b.children[0].children
+
+    def test_depth_does_not_hide_growth_totals(self):
+        # Growth lives at the leaf level (GrowthSpar.e); the top budget variable
+        # has no growth itself.  Requesting depth=1 stops expansion at the spar
+        # row, but the cbe/ga totals and has_growth must still reflect the full tree.
+        model = BareParentGrowthChild()
+        sol, _ = solve(model)
+        b = build_budget(sol, model, model.m, depth=1)
+        assert b.has_growth is True
+        assert b.ga_total == pytest.approx(10.0, rel=1e-4)
+        spar_node = next(n for n in b.children if n.vk and "Spar" in n.vk.lineagestr())
+        assert spar_node.has_growth is True
+        assert spar_node.ga_value == pytest.approx(10.0, rel=1e-4)
+        assert not spar_node.children  # depth=1: display is trimmed
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `depth=` on `build_budget` was being applied during tree construction, which stopped expansion before growth-declaring leaves were reached. Any growth living below the depth cutoff would be invisible in cbe/ga totals and `has_growth` flags — even at the top-level Budget row.
- Fix: always build the full constraint tree and compute cbe/ga/has_growth at full depth; apply `depth` only as a display trim after computation. A new `_trim_to_depth` helper prunes `node.children` in-place after cbe/ga values are already set, and handles `float("inf")` naturally (never hits `<= 0`), eliminating any conditional at the call site.
- Same fix correctly handles a second case: bare additive parents (`m >= m1 + m2`, no `grown_from`) above a growth-declaring child — growth now propagates up through them regardless of depth.

## Test plan

- [x] `uv run pytest gpkit/tests/test_budgets.py` — 84 tests, all pass
- New `TestBareParentWithGrowthChild` class (8 tests): 2-level and 3-level bare-parent hierarchies with a growth leaf
- New `test_depth_does_not_hide_growth_totals`: `depth=1` on a model whose growth lives at depth 2 — verifies `Budget.has_growth`, `ga_total`, and the trimmed child node all show the correct accumulated growth