### PR TITLE
refactor examples to allow importing without solve

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,5 @@ jobs:
 
     - name: Check for file changes
       run: |
+        git diff
         make check-clean

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,10 @@ jobs:
     - name: Install
       run: uv sync --group test
 
+    - name: Regenerate example outputs
+      run: |
+        make examples
+
     - name: Run tests with coverage
       run: |
         make coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Install
       run: uv sync --group test
 
+    - name: Build gpkit (configure solvers)
+      run: uv run python -c "import gpkit"
+
     - name: Regenerate example outputs
       run: |
         make examples

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,11 @@ format:
 	uv run black gpkit
 
 # Testing
-test:  # Run tests with pytest
+regen-examples:  # Regenerate catalog example output files for docs
+	uv run python scripts/regen_examples.py
+
+test:  # Regenerate catalog example outputs, then run all tests
+	$(MAKE) regen-examples
 	uv run pytest gpkit/tests -v
 
 coverage:  # Run tests with coverage reporting
@@ -44,7 +48,8 @@ help:
 	@echo "  lint              Run fast lint checks"
 	@echo "  pylint            Run pylint (slow)"
 	@echo "  format            Format code with isort and black"
-	@echo "  test              Run tests with pytest"
+	@echo "  regen-examples    Regenerate catalog example output files"
+	@echo "  test              Regen examples, then run all tests"
 	@echo "  coverage          Run tests with coverage reporting"
 	@echo "  clean             Clean build artifacts"
 	@echo "  check-clean       Check no uncommitted changes"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean check-clean test coverage lint pylint format
+.PHONY: clean check-clean test coverage lint pylint format examples
 
 # Code quality
 lint:
@@ -14,11 +14,10 @@ format:
 	uv run black gpkit
 
 # Testing
-regen-examples:  # Regenerate catalog example output files for docs
+examples:  # Regenerate catalog example output files for docs
 	uv run python scripts/regen_examples.py
 
-test:  # Regenerate catalog example outputs, then run all tests
-	$(MAKE) regen-examples
+test:  # Run all tests
 	uv run pytest gpkit/tests -v
 
 coverage:  # Run tests with coverage reporting
@@ -48,8 +47,8 @@ help:
 	@echo "  lint              Run fast lint checks"
 	@echo "  pylint            Run pylint (slow)"
 	@echo "  format            Format code with isort and black"
-	@echo "  regen-examples    Regenerate catalog example output files"
-	@echo "  test              Regen examples, then run all tests"
+	@echo "  examples          Regenerate catalog example output files"
+	@echo "  test              Run all tests"
 	@echo "  coverage          Run tests with coverage reporting"
 	@echo "  clean             Clean build artifacts"
 	@echo "  check-clean       Check no uncommitted changes"

--- a/catalog.toml
+++ b/catalog.toml
@@ -1,49 +1,93 @@
-# catalog.toml — model registry for gpkit-core examples
-#
-# Schema:
-#   module — Python import path
-#   class  — class name within that module
-#
-# All registered models must implement default() classmethod.
-# Registration implies compliance: a model cannot appear here without a passing
-# CI test via test_catalog.py.
+# gpkit-core built-in examples catalog
+# Each entry is a standalone GP model from gpkit.examples.*
+# expected_cost / expected_cost_tol drive parametrized tests in test_catalog.py
 
 [[models]]
+id = "box"
+name = "Simple Box"
+description = "Maximize box volume given area and aspect ratio constraints"
 module = "gpkit.examples.simple_box"
 class = "Box"
+expected_cost = 0.003674
+expected_cost_tol = 0.01
 
 [[models]]
+id = "water_tank"
+name = "Water Tank"
+description = "Minimize rectangular tank surface area for a particular volume"
 module = "gpkit.examples.water_tank"
 class = "WaterTank"
+expected_cost = 1.293
+expected_cost_tol = 0.01
 
 [[models]]
-module = "gpkit.examples.bemt_hover"
-class = "BEMTHover"
-
-[[models]]
-module = "gpkit.examples.fuel_burn"
-class = "FuelBurn"
-
-[[models]]
+id = "beam"
+name = "Euler Beam"
+description = "Discretized Euler-Bernoulli beam equations with distributed load"
 module = "gpkit.examples.beam"
 class = "Beam"
+expected_cost = 0.7825
+expected_cost_tol = 0.001
 
 [[models]]
+id = "fuel_burn"
+name = "Fuel Burn"
+description = "Multi-point aircraft fuel burn minimization"
+module = "gpkit.examples.fuel_burn"
+class = "FuelBurn"
+expected_cost = 7561.15
+expected_cost_tol = 0.01
+
+[[models]]
+id = "box_transport"
+name = "Box Transport"
+description = "Minimize ferry and box cost to transport a fixed volume of gravel"
 module = "gpkit.examples.gp_textbook"
 class = "BoxTransport"
+expected_cost = 100.0
+expected_cost_tol = 0.01
 
 [[models]]
+id = "fence_plot"
+name = "Fence Plot"
+description = "Maximize rectangular plot area with a fixed fence length"
 module = "gpkit.examples.gp_textbook"
 class = "FencePlot"
+expected_cost = 8.0
+expected_cost_tol = 0.01
 
 [[models]]
+id = "beam_cross_section"
+name = "Beam Cross-Section"
+description = "Maximize bending stiffness of a rectangular beam cut from a log"
 module = "gpkit.examples.gp_textbook"
 class = "BeamCrossSection"
+expected_cost = 0.1925
+expected_cost_tol = 0.01
 
 [[models]]
+id = "box_from_sheet"
+name = "Box from Sheet"
+description = "Maximize open-top box volume cut from a square tin sheet"
 module = "gpkit.examples.gp_textbook"
 class = "BoxFromSheet"
+expected_cost = 13.5
+expected_cost_tol = 0.01
 
 [[models]]
+id = "work_sleep"
+name = "Work/Sleep Allocation"
+description = "Maximize daily savings with work/sleep/leisure time allocation"
 module = "gpkit.examples.gp_textbook"
 class = "WorkSleep"
+expected_cost = 0.009006
+expected_cost_tol = 0.01
+
+[[models]]
+id = "wing"
+name = "Wing Mass Budget"
+description = "Wing spar mass budget with layered growth allowances"
+module = "gpkit.examples.growth_allowance"
+class = "Wing"
+expected_cost = 35.64
+expected_cost_tol = 0.001

--- a/catalog.toml
+++ b/catalog.toml
@@ -4,8 +4,6 @@
 
 [[models]]
 id = "box"
-name = "Simple Box"
-description = "Maximize box volume given area and aspect ratio constraints"
 module = "gpkit.examples.simple_box"
 class = "Box"
 expected_cost = 0.003674
@@ -13,8 +11,6 @@ expected_cost_tol = 0.01
 
 [[models]]
 id = "water_tank"
-name = "Water Tank"
-description = "Minimize rectangular tank surface area for a particular volume"
 module = "gpkit.examples.water_tank"
 class = "WaterTank"
 expected_cost = 1.293
@@ -22,8 +18,6 @@ expected_cost_tol = 0.01
 
 [[models]]
 id = "beam"
-name = "Euler Beam"
-description = "Discretized Euler-Bernoulli beam equations with distributed load"
 module = "gpkit.examples.beam"
 class = "Beam"
 expected_cost = 0.7825
@@ -31,18 +25,13 @@ expected_cost_tol = 0.001
 
 [[models]]
 id = "fuel_burn"
-name = "Fuel Burn"
-description = "Multi-point aircraft fuel burn minimization"
 module = "gpkit.examples.fuel_burn"
 class = "FuelBurn"
 expected_cost = 7561.15
 expected_cost_tol = 0.01
 
-
 [[models]]
 id = "wing"
-name = "Wing Mass Budget"
-description = "Wing spar mass budget with layered growth allowances"
 module = "gpkit.examples.growth_allowance"
 class = "Wing"
 expected_cost = 35.64

--- a/catalog.toml
+++ b/catalog.toml
@@ -6,33 +6,33 @@
 id = "box"
 module = "gpkit.examples.simple_box"
 class = "Box"
-expected_cost = 0.003674
-expected_cost_tol = 0.01
 
 [[models]]
 id = "water_tank"
 module = "gpkit.examples.water_tank"
 class = "WaterTank"
-expected_cost = 1.293
-expected_cost_tol = 0.01
 
 [[models]]
 id = "beam"
 module = "gpkit.examples.beam"
 class = "Beam"
-expected_cost = 0.7825
-expected_cost_tol = 0.001
 
 [[models]]
 id = "fuel_burn"
 module = "gpkit.examples.fuel_burn"
 class = "FuelBurn"
-expected_cost = 7561.15
-expected_cost_tol = 0.01
 
 [[models]]
 id = "wing"
 module = "gpkit.examples.growth_allowance"
 class = "Wing"
-expected_cost = 35.64
-expected_cost_tol = 0.001
+
+[[models]]
+id = "bemt_hover"
+module = "gpkit.examples.bemt_hover"
+class = "BEMTHover"
+
+[[models]]
+id = "bemt_hover"
+module = "gpkit.examples.bemt_hover"
+class = "BEMTHover"

--- a/catalog.toml
+++ b/catalog.toml
@@ -38,50 +38,6 @@ class = "FuelBurn"
 expected_cost = 7561.15
 expected_cost_tol = 0.01
 
-[[models]]
-id = "box_transport"
-name = "Box Transport"
-description = "Minimize ferry and box cost to transport a fixed volume of gravel"
-module = "gpkit.examples.gp_textbook"
-class = "BoxTransport"
-expected_cost = 100.0
-expected_cost_tol = 0.01
-
-[[models]]
-id = "fence_plot"
-name = "Fence Plot"
-description = "Maximize rectangular plot area with a fixed fence length"
-module = "gpkit.examples.gp_textbook"
-class = "FencePlot"
-expected_cost = 8.0
-expected_cost_tol = 0.01
-
-[[models]]
-id = "beam_cross_section"
-name = "Beam Cross-Section"
-description = "Maximize bending stiffness of a rectangular beam cut from a log"
-module = "gpkit.examples.gp_textbook"
-class = "BeamCrossSection"
-expected_cost = 0.1925
-expected_cost_tol = 0.01
-
-[[models]]
-id = "box_from_sheet"
-name = "Box from Sheet"
-description = "Maximize open-top box volume cut from a square tin sheet"
-module = "gpkit.examples.gp_textbook"
-class = "BoxFromSheet"
-expected_cost = 13.5
-expected_cost_tol = 0.01
-
-[[models]]
-id = "work_sleep"
-name = "Work/Sleep Allocation"
-description = "Maximize daily savings with work/sleep/leisure time allocation"
-module = "gpkit.examples.gp_textbook"
-class = "WorkSleep"
-expected_cost = 0.009006
-expected_cost_tol = 0.01
 
 [[models]]
 id = "wing"

--- a/docs/source/examples/bemt_hover_output.txt
+++ b/docs/source/examples/bemt_hover_output.txt
@@ -1,0 +1,93 @@
+
+           ┃┓           ┓          ^┓
+           ┃┃           ┃           ┃
+           ┃┃           ┣╸dP[0]    ^┣╸1/dC_T[2]
+           ┃┃           ┛ (9,235W) ^┛ (24.3)
+           ┃┃           ┓          ^┓
+           ┃┃           ┃           ┃
+           ┃┃           ┣╸dP[1]    ^┣╸1/dC_T[2]
+           ┃┃           ┛ (8,818W) ^┛
+           ┃┃           ┓          ^┓
+      Cost╺┫┃           ┃           ┃
+ (43,582W) ┃┣╸P         ┣╸dP[2]    ^┣╸1/dC_T[2]
+           ┃┃ (43,582W) ┛ (8,818W) ^┛
+           ┃┃           ┓          ^┓
+           ┃┃           ┃           ┃
+           ┃┃           ┣╸dP[3]    ^┣╸1/dC_T[2]
+           ┃┃           ┛ (8,818W) ^┛
+           ┃┃           ┓          ^┓
+           ┃┃           ┃           ┃
+           ┃┃           ┣╸dP[4]    ^┣╸1/dC_T[2]
+           ┃┛           ┛ (7,895W) ^┛
+
+
+
+           ┃┣╸P ≥ dP[:].sum()
+           ┃┓
+           ┃┃
+ BEMTHover╺┫┃
+           ┃┣╸[35 terms]
+           ┃┃
+           ┃┃
+           ┃┛
+
+
+Optimal Cost
+------------
+BEMTHover.P : 4.358e+04 [W]
+
+Solution
+--------
+BEMTHover
+          A : 201.1     [m²]           disk area
+      Omega : 16.73     [rpm]          rotor RPM
+          P : 4.358e+04 [W]            total induced power
+          R : 8         [m]            rotor radius
+     V_i[:] : [ 4.62      4.41      4.41      4.41      3.95     ] [m/s] induced velocity
+\Delta r[:] : [ 0.435     0.177     0.139     0.119     0.13     ]       non-dimensional radius step
+    dC_P[:] : [ 0.0136    0.0129    0.0129    0.0129    0.0116   ]       incremental power coefficient
+    dC_T[:] : [ 0.0412    0.0412    0.0412    0.0412    0.0412   ]       incremental thrust coefficient
+      dP[:] : [ 9.24e+03  8.82e+03  8.82e+03  8.82e+03  7.89e+03 ] [W]   incremental power
+       r[:] : [ 0.218     0.589     0.747     0.876     1        ]       non-dimensional radius
+...constants
+      R_max : 8         [m]     (-1)   maximum rotor radius
+        rho : 1.23      [kg/m³] (-0.5) air density
+     dr_min : 0.001             (~0)   minimum bin width (non-dimensional)
+  Omega_max : 280       [rpm]   (~0)   maximum rotor RPM
+  Omega_min : 1         [rpm]   (~0)   minimum rotor RPM
+      R_min : 0.1       [m]     (~0)   minimum rotor radius
+     \xi[:] : [ 2e+03   2e+03   2e+03   2e+03   2e+03  ] [N]   thrust per bin (fixed)
+         sens ( +0.318  +0.303  +0.303  +0.303  +0.272 )
+
+Most Sensitive Constraints
+--------------------------
+BEMTHover
++1      : P ≥ dP[:].sum()
++1      : R ≤ R_max
++0.5134 : r[4] ≤ 1
++0.5    : A = 3.14·R²
++0.4866 : \Delta r[:].sum() ≤ 1
++0.4228 : r[4] ≥ r[3] + 0.5·\Delta r[3] + 0.5·\Delta r[4]
+-0.3179 : V_i[0]²·r[0]·\Delta r[0]/(dC_T[0]·(Omega·R)²) = 0.25
++0.3179 : \xi[0] = rho·A·(Omega·R)²·dC_T[0]
+-0.3035 : V_i[1]²·r[1]·\Delta r[1]/(dC_T[1]·(Omega·R)²) = 0.25
++0.3035 : \xi[1] = rho·A·(Omega·R)²·dC_T[1]
+-0.3035 : V_i[2]²·r[2]·\Delta r[2]/(dC_T[2]·(Omega·R)²) = 0.25
++0.3035 : \xi[2] = rho·A·(Omega·R)²·dC_T[2]
+-0.3035 : V_i[3]²·r[3]·\Delta r[3]/(dC_T[3]·(Omega·R)²) = 0.25
++0.3035 : \xi[3] = rho·A·(Omega·R)²·dC_T[3]
+-0.2717 : V_i[4]²·r[4]·\Delta r[4]/(dC_T[4]·(Omega·R)²) = 0.25
++0.2717 : \xi[4] = rho·A·(Omega·R)²·dC_T[4]
++0.2691 : r[3] ≥ r[2] + 0.5·\Delta r[2] + 0.5·\Delta r[3]
++0.2119 : V_i[0]³·r[0]·\Delta r[0]/(dC_P[0]·(Omega·R)³) = 0.25
+-0.2119 : dP[0] = rho·A·(Omega·R)³·dC_P[0]
++0.2023 : V_i[1]³·r[1]·\Delta r[1]/(dC_P[1]·(Omega·R)³) = 0.25
+-0.2023 : dP[1] = rho·A·(Omega·R)³·dC_P[1]
++0.2023 : V_i[2]³·r[2]·\Delta r[2]/(dC_P[2]·(Omega·R)³) = 0.25
+-0.2023 : dP[2] = rho·A·(Omega·R)³·dC_P[2]
++0.2023 : V_i[3]³·r[3]·\Delta r[3]/(dC_P[3]·(Omega·R)³) = 0.25
+-0.2023 : dP[3] = rho·A·(Omega·R)³·dC_P[3]
++0.1811 : V_i[4]³·r[4]·\Delta r[4]/(dC_P[4]·(Omega·R)³) = 0.25
+-0.1811 : dP[4] = rho·A·(Omega·R)³·dC_P[4]
++0.1283 : r[2] ≥ r[1] + 0.5·\Delta r[1] + 0.5·\Delta r[2]
++0.106  : r[0] = \Delta r[0]/2

--- a/docs/source/examples/fuel_burn_output.txt
+++ b/docs/source/examples/fuel_burn_output.txt
@@ -1,0 +1,149 @@
+
+          ┃┓           /┓           ┓
+          ┃┃            ┃           ┃
+          ┃┃            ┃           ┃
+          ┃┃            ┃           ┃
+          ┃┃            ┃           ┃
+          ┃┣╸W_fuel[0] /┣╸W[0]      ┣╸W_zfw╶⎨
+          ┃┃ (3,975N)   ┃ (35,792N) ┃ (32,206N)
+          ┃┃            ┃           ┃
+          ┃┃            ┃           ┃
+     Cost╺┫┃            ┃           ┛
+ (7,561N) ┃┛           /┛           ┣╸W_fuel[1]
+          ┃┓           ┓       ┓           ┓
+          ┃┃           ┃       ┃           ┃
+          ┃┃           ┃       ┃           ┣╸W_fixed
+          ┃┃           ┃       ┣╸W_tw      ┛ (14,700N, fixed)
+          ┃┣╸W_fuel[1] ┣╸W_zfw ┃ (23,107N) ┣╸W_pay
+          ┃┃           ┃       ┛           ┣╸W_eng
+          ┃┃           ┃       ┓          ┓
+          ┃┃           ┃       ┣╸W_wing   ┣╸I_cap/t_cap
+          ┃┛           ┛       ┛ (9,099N) ┛ (0.0126m⁴)
+
+
+
+          ┃
+ FuelBurn╺┫
+          ┃
+          ┃
+
+
+Optimal Cost
+------------
+FuelBurn.W_fuel[:].sum() : 7561 [N]
+
+Solution
+--------
+FuelBurn
+             A : 21.08                            aspect ratio
+         I_cap : 6.709e-05 [m⁴]                   spar cap area moment of inertia per unit chord
+        M_rbar : 4.466e+04                        normalized root bending moment
+         P_max : 1.423e+06 [W]                    maximum shaft power
+             R : 5e+06     [m]                    airplane range
+             S : 26.94     [m²]                   wing area
+       V_stall : 40        [m/s]                  stall speed
+         W_cap : 4379      [N]                    spar cap weight
+         W_eng : 3502      [N]                    engine weight
+         W_mto : 3.977e+04 [N]                    maximum takeoff weight
+          W_tw : 2.311e+04 [N]                    tare weight (fixed + payload + engine)
+         W_web : 171.1     [N]                    shear web weight
+        W_wing : 9099      [N]                    wing weight
+         W_zfw : 3.221e+04 [N]                    zero fuel weight
+            nu : 0.7658                           wing taper/shape parameter
+             p : 2.2                              wing taper ratio parameter
+             q : 1.6                              wing taper ratio parameter 2
+         t_cap : 0.005321                         spar cap thickness/chord ratio
+         t_web : 0.0005545                        shear web thickness/chord ratio
+           tau : 0.2499                           airfoil thickness/chord ratio
+        C_D[:] : [ 0.016     0.0161    0.00951  ]       wing drag coefficient
+        C_L[:] : [ 0.67      0.671     0.13     ]       wing lift coefficient
+    C_{D_p}[:] : [ 0.00704   0.00708   0.00739  ]       profile drag coefficient
+         Re[:] : [ 4.02e+06  3.81e+06  9.13e+06 ]       Reynolds number
+          T[:] : [ 856       772       2.62e+03 ] [N]   thrust force
+          V[:] : [ 66        62.6      150      ] [m/s] flight speed
+          W[:] : [ 3.58e+04  3.22e+04  3.58e+04 ] [N]   aircraft weight
+     W_fuel[:] : [ 3.97e+03  3.59e+03 ] [N]   fuel weight per segment
+     \eta_0[:] : [ 0.265     0.265     0.277    ]       overall propulsive efficiency
+     \eta_i[:] : [ 0.891     0.891     0.929    ]       ideal propulsive efficiency
+\eta_{prop}[:] : [ 0.757     0.757     0.79     ]       propeller efficiency
+      z_bre[:] : [ 0.105     0.106    ]       Breguet range parameter
+...constants
+             g : 9.8       [m/s²]      (+1.504)   gravitational constant
+       eta_eng : 0.35                  (-1.311)   engine efficiency
+         eta_v : 0.85                  (-1.311)   propeller viscous efficiency
+         R_min : 5e+06     [m]         (+1.16)    minimum airplane range
+        h_fuel : 4.2e+07   [J/kg]      (-1.16)    fuel heating value
+       W_fixed : 1.47e+04  [N]         (+0.7854)  fixed weight
+             e : 0.95                  (-0.571)   wing spanwise efficiency
+    V_stallmax : 40        [m/s]       (-0.4952)  stall speed limit
+ V_sprint_reqt : 150       [m/s]       (+0.4452)  sprint speed requirement
+        N_lift : 6                     (+0.3609)  wing loading multiplier
+        EI_ref : 1         [m⁶·Pa]     (+0.348)   structural normalization stiffness
+         W_ref : 1         [N]         (-0.348)   structural normalization weight
+     sigma_max : 2.5e+08   [Pa]        (-0.348)   allowable stress, 6061-T6
+       k_shear : 1         [1/m⁴]      (+0.348)   structural normalization shear factor
+        f_wadd : 2                     (+0.344)   wing added weight fraction
+      rho_alum : 2700      [kg/m³]     (+0.344)   density of aluminum
+         W_pay : 4905      [N]         (+0.2621)  payload weight
+        C_Lmax : 1.5                   (-0.2476)  maximum C_L, flaps down
+        rho_sl : 1.23      [kg/m³]     (-0.2476)  air density, sea level
+   W_eng_coeff : 0.0372    [N/W⁰⋅⁸⁰⁸³] (+0.1871)  engine weight fit coefficient
+          CDA0 : 0.05      [m²]        (+0.1787)  fuselage zero-lift drag area
+        A_prop : 0.785     [m²]        (-0.1242)  propeller disk area
+           rho : 0.91      [kg/m³]     (+0.1129)  air density, 3000m
+            mu : 1.69e-05  [kg/m/s]    (+0.06818) dynamic viscosity, 3000m
+             w : 0.5                   (-0.01689) wing-box width/chord
+           r_h : 0.75                  (+0.01294) wing strut taper parameter
+sigma_maxshear : 1.67e+08  [Pa]        (-0.01294) allowable shear stress
+
+Most Sensitive Constraints
+--------------------------
+FuelBurn
++1.235   : W_tw ≥ W_fixed + W_pay + W_eng
++1.218   : W_zfw ≥ W_tw + W_wing
++1.16    : R ≥ R_min
++0.7964  : p ≥ 2.2
++0.7578  : W[0] ≥ W_zfw + W_fuel[1]
++0.7219  : 2·q ≥ 1 + p
++0.637   : C_D[1] ≥ C_{D_p}[1] + CDA0/S + C_L[1]²/(π·e·A)
++0.637   : T[1] ≥ 0.5·rho·C_D[1]·S·V[1]²
++0.637   : C_D[0] ≥ C_{D_p}[0] + CDA0/S + C_L[0]²/(π·e·A)
++0.637   : T[0] ≥ 0.5·rho·C_D[0]·S·V[0]²
++0.5799  : \eta_0[0] ≤ eta_eng·\eta_{prop}[0]
++0.5799  : \eta_{prop}[0] ≤ \eta_i[0]·eta_v
++0.5799  : z_bre[0] ≥ g·R·T[0]/(h_fuel·\eta_0[0]·W[0])
++0.5798  : \eta_0[1] ≤ eta_eng·\eta_{prop}[1]
++0.5798  : \eta_{prop}[1] ≤ \eta_i[1]·eta_v
++0.5798  : z_bre[1] ≥ g·R·T[1]/(h_fuel·\eta_0[1]·W[1])
++0.5657  : W[0] = 0.5·rho·C_L[0]·S·V[0]²
++0.5654  : W[1] = 0.5·rho·C_L[1]·S·V[1]²
++0.5504  : W_fuel[0]/W[0] ≥ z_bre[0]^1 + z_bre[0]²/2 + z_bre[0]³/6 + z_bre[0]⁴/24
++0.5502  : W_fuel[1]/W[1] ≥ z_bre[1]^1 + z_bre[1]²/2 + z_bre[1]³/6 + z_bre[1]⁴/24
++0.5358  : W[1] ≥ W_zfw
++0.5229  : \eta_i[0]·4 + T[0]·\eta_i[0]²/(0.5·rho·V[0]²·A_prop) ≤ 4
++0.5226  : \eta_i[1]·4 + T[1]·\eta_i[1]²/(0.5·rho·V[1]²·A_prop) ≤ 4
++0.4952  : V_stall ≤ V_stallmax
++0.4452  : V[2] ≥ V_sprint_reqt
++0.3649  : 0.423·w·tau²·t_cap ≥ I_cap·k_shear + 0.92·w·tau·t_cap²
++0.348   : M_rbar ≥ W_tw·A·p/(24·W_ref)
++0.348   : N_lift·M_rbar·A·q²·tau·EI_ref/(S·I_cap·sigma_max) ≤ 8
++0.344   : W_wing/f_wadd ≥ W_cap + W_web
++0.3311  : W_cap ≥ 8·rho_alum·g·w·t_cap·S^1.5·nu/(3·A^0.5)
++0.2476  : W_mto ≤ 0.5·rho_sl·V_stall²·C_Lmax·S
++0.2476  : W_mto ≥ W[0] + W_fuel[0]
++0.1871  : W_eng ≥ W_eng_coeff·P_max^0.8083
++0.1612  : C_D[2] ≥ C_{D_p}[2] + CDA0/S + C_L[2]²/(π·e·A)
++0.1612  : T[2] ≥ 0.5·rho·C_D[2]·S·V[2]²
++0.1512  : P_max ≥ T[2]·V[2]/\eta_0[2]
++0.1512  : \eta_0[2] ≤ eta_eng·\eta_{prop}[2]
++0.1512  : \eta_{prop}[2] ≤ \eta_i[2]·eta_v
++0.1413  : \eta_i[2]·4 + T[2]·\eta_i[2]²/(0.5·rho·V[2]²·A_prop) ≤ 4
++0.08732 : nu^3.94 ≥ 0.86·p^-2.38 + 0.14·p^0.56
++0.07895 : C_L[0]^5.88·2.56/(Re[0]^1.54·tau^3.32·C_{D_p}[0]^2.62) + (C_L[0]^0.92·Re[0]^1.38·C_{D_p}[0]^9.57)^-1·3.8e-09·tau^6.23 + Re[0]^0.14·0.0022·tau^0.033/(C_L[0]^0.01·C_{D_p}[0]^0.73) + C_L[0]^9.78·1.19e+04·tau^1.76/(Re[0]·C_{D_p}[0]^0.91) + C_L[0]^6.53·6.14e-06/(Re[0]^0.99·tau^0.52·C_{D_p}[0]^5.19) ≤ 1
++0.07779 : C_L[1]^5.88·2.56/(Re[1]^1.54·tau^3.32·C_{D_p}[1]^2.62) + (C_L[1]^0.92·Re[1]^1.38·C_{D_p}[1]^9.57)^-1·3.8e-09·tau^6.23 + Re[1]^0.14·0.0022·tau^0.033/(C_L[1]^0.01·C_{D_p}[1]^0.73) + C_L[1]^9.78·1.19e+04·tau^1.76/(Re[1]·C_{D_p}[1]^0.91) + C_L[1]^6.53·6.14e-06/(Re[1]^0.99·tau^0.52·C_{D_p}[1]^5.19) ≤ 1
++0.03988 : C_L[2]^5.88·2.56/(Re[2]^1.54·tau^3.32·C_{D_p}[2]^2.62) + (C_L[2]^0.92·Re[2]^1.38·C_{D_p}[2]^9.57)^-1·3.8e-09·tau^6.23 + Re[2]^0.14·0.0022·tau^0.033/(C_L[2]^0.01·C_{D_p}[2]^0.73) + C_L[2]^9.78·1.19e+04·tau^1.76/(Re[2]·C_{D_p}[2]^0.91) + C_L[2]^6.53·6.14e-06/(Re[2]^0.99·tau^0.52·C_{D_p}[2]^5.19) ≤ 1
++0.02884 : Re[1] = rho/mu·V[1]·(S/A)^0.5
++0.0284  : Re[0] = rho/mu·V[0]·(S/A)^0.5
++0.01294 : A·W_tw·N_lift·q²/(tau·S·t_web·sigma_maxshear) ≤ 12
++0.01294 : W_web ≥ 8·rho_alum·g·r_h·tau·t_web·S^1.5·nu/(3·A^0.5)
++0.01094 : Re[2] = rho/mu·V[2]·(S/A)^0.5

--- a/docs/source/examples/gp_textbook_output.txt
+++ b/docs/source/examples/gp_textbook_output.txt
@@ -1,0 +1,210 @@
+=== 1. Box Transport ===
+
+       ┃┓
+       ┃┃
+       ┃┃
+       ┃┣╸1/h/length/w
+       ┃┃ (1)
+       ┃┃
+       ┃┛
+  Cost╺┫┓
+ (100) ┃┣╸h·w
+       ┃┛ (0.5)
+       ┃┓
+       ┃┣╸h·length
+       ┃┛ (1)
+       ┃┓
+       ┃┣╸length·w
+       ┃┛ (2)
+
+
+
+              ┃┓
+              ┃┃
+              ┃┣╸V1 = 400
+              ┃┃
+              ┃┛
+              ┃┓
+              ┃┃
+ BoxTransport╺┫┣╸c_ferry = 0.1
+              ┃┃
+              ┃┛
+              ┃┓
+              ┃┃
+              ┃┣╸c_sides = 10
+              ┃┛
+              ┃┣╸c_ends = 20
+              ┃┛
+
+
+Optimal Cost
+------------
+BoxTransport.c_ferry·BoxTransport.V1/(BoxTransport.length·BoxTransport.w·BoxTransport.h) + BoxTransport.c_ends·2·BoxTransport.w·BoxTransport.h + BoxTransport.c_sides·(2·BoxTransport.length·BoxTransport.h + BoxTransport.w·BoxTransport.length) : 100
+
+Solution
+--------
+BoxTransport
+      h : 0.5         box height
+ length : 2           box length
+      w : 1           box width
+...constants
+c_sides : 10   (+0.4) cost of box sides and bottom (per unit area)
+     V1 : 400  (+0.4) volume of gravel to transport
+c_ferry : 0.1  (+0.4) cost per ferry trip
+ c_ends : 20   (+0.2) cost of box ends (per unit area)
+
+=== 2. Fence Plot ===
+
+      ┃┓
+ Cost╺┫┃
+  (8) ┃┣╸1/(length·w)
+      ┃┛ (8)
+
+
+
+           ┃┓
+           ┃┃
+           ┃┣╸L = 1
+ FencePlot╺┫┛
+           ┃┓
+           ┃┃
+           ┃┣╸L ≥ 2·w + length
+           ┃┛
+
+
+Optimal Cost
+------------
+1/(FencePlot.length·FencePlot.w) : 8
+
+Solution
+--------
+FencePlot
+length : 0.5        plot side parallel to river
+     w : 0.25       plot side perpendicular to river
+...constants
+     L : 1     (-2) total fence length
+
+=== 3. Beam Cross-Section ===
+
+         ┃┓
+    Cost╺┫┃
+ (0.192) ┃┣╸1/(w·d³)
+         ┃┛ (0.192)
+
+
+
+                  ┃┓
+                  ┃┃
+                  ┃┣╸R = 1
+ BeamCrossSection╺┫┃
+                  ┃┛
+                  ┃┓
+                  ┃┣╸R² ≥ (d/2)² + (w/2)²
+                  ┃┛
+
+
+Optimal Cost
+------------
+1/(BeamCrossSection.w·BeamCrossSection.d³) : 0.1925
+
+Solution
+--------
+BeamCrossSection
+d : 1.732       beam depth
+w : 1           beam width
+...constants
+R : 1      (-4) log radius
+
+=== 4. Box from Sheet ===
+
+        ┃┓
+   Cost╺┫┃
+ (13.5) ┃┣╸1/(length·w·h)
+        ┃┛ (13.5)
+
+
+
+              ┃┓
+              ┃┃
+              ┃┃
+              ┃┃
+              ┃┃
+              ┃┣╸L = 1
+              ┃┃
+              ┃┃
+              ┃┃
+ BoxFromSheet╺┫┛
+              ┃┓
+              ┃┃
+              ┃┣╸L ≥ length + 2·cy
+              ┃┛
+              ┃┓
+              ┃┃
+              ┃┣╸L ≥ w + 2·cx
+              ┃┛
+              ┃┣╸cx ≥ h
+              ┃┣╸cy ≥ h
+
+
+Optimal Cost
+------------
+1/(BoxFromSheet.length·BoxFromSheet.w·BoxFromSheet.h) : 13.5
+
+Solution
+--------
+BoxFromSheet
+    cx : 0.1667       corner cutout length in x dimension
+    cy : 0.1667       corner cutout length in y dimension
+     h : 0.1667       box height
+length : 0.6667       box length
+     w : 0.6667       box width
+...constants
+     L : 1       (-3) tin sheet side length
+
+=== 5. Work/Sleep Allocation ===
+
+           ┃┓
+      Cost╺┫┃
+ (0.00901) ┃┣╸1/s
+           ┃┛ (0.00901)
+
+
+
+           ┃┓
+           ┃┃
+           ┃┃
+           ┃┃
+           ┃┃
+           ┃┣╸tw + ts + to ≤ 24
+           ┃┃
+           ┃┃
+           ┃┃
+ WorkSleep╺┫┛
+           ┃┓
+           ┃┃
+           ┃┣╸p = 0.5
+           ┃┛
+           ┃┓
+           ┃┃
+           ┃┣╸p·tw^1.5·ts^0.75·tm^0.1 ≥ s + c·tm
+           ┃┛
+           ┃┣╸te = 3
+           ┃┣╸to ≥ te
+
+
+Optimal Cost
+------------
+1/WorkSleep.s : 0.009006
+
+Solution
+--------
+WorkSleep
+ s : 111              savings accrued per day
+tm : 2.467            hours spent listening to music
+to : 3                hours spent eating and/or listening
+ts : 7                hours spent sleeping
+tw : 14               hours spent working
+...constants
+ p : 0.5    (-1.111)  pay rate per unit productivity
+te : 3      (+0.3571) hours required for eating
+ c : 5      (+0.1111) cost of new records per hour

--- a/gpkit/examples/beam.py
+++ b/gpkit/examples/beam.py
@@ -64,29 +64,33 @@ class Beam(Model):
         }
 
 
-b = Beam(N=6, substitutions={"L": 6, "EI": 1.1e4, "q": 110 * np.ones(6)})
-sol = b.solve(verbosity=0)
-print(sol.summary(vecn=6))
-w_gp = sol["w"]  # deflection along beam
+if __name__ == "__main__":
+    b = Beam(N=6, substitutions={"L": 6, "EI": 1.1e4, "q": 110 * np.ones(6)})
+    sol = b.solve(verbosity=0)
+    print(sol.summary(vecn=6))
+    w_gp = sol["w"]
 
-L, EI, q_vec = sol["L"], sol["EI"], sol["q"]
-x = np.linspace(0, mag(L), len(q_vec)) * ureg.m  # position along beam
-q_uniform = q_vec[0]  # assume uniform loading for the check below
-w_exact = q_uniform / (24 * EI) * x**2 * (x**2 - 4 * L * x + 6 * L**2)  # analytic soln
-assert max(abs(w_gp - w_exact)) <= 1.1 * ureg.cm
+    L, EI, q_vec = sol["L"], sol["EI"], sol["q"]
+    x = np.linspace(0, mag(L), len(q_vec)) * ureg.m
+    q_uniform = q_vec[0]
+    w_exact = q_uniform / (24 * EI) * x**2 * (x**2 - 4 * L * x + 6 * L**2)
+    assert max(abs(w_gp - w_exact)) <= 1.1 * ureg.cm
 
-PLOT = False
-if PLOT:  # pragma: no cover
-    import matplotlib.pyplot as plt
+    PLOT = False
+    if PLOT:
+        import matplotlib.pyplot as plt
 
-    x_exact = np.linspace(0, L, 1000)
-    w_exact = (
-        q_uniform / (24 * EI) * x_exact**2 * (x_exact**2 - 4 * L * x_exact + 6 * L**2)
-    )
-    plt.plot(x, w_gp, color="red", linestyle="solid", marker="^", markersize=8)
-    plt.plot(x_exact, w_exact, color="blue", linestyle="dashed")
-    plt.xlabel("x [m]")
-    plt.ylabel("Deflection [m]")
-    plt.axis("equal")
-    plt.legend(["GP solution", "Analytical solution"])
-    plt.show()
+        x_exact = np.linspace(0, L, 1000)
+        w_exact = (
+            q_uniform
+            / (24 * EI)
+            * x_exact**2
+            * (x_exact**2 - 4 * L * x_exact + 6 * L**2)
+        )
+        plt.plot(x, w_gp, color="red", linestyle="solid", marker="^", markersize=8)
+        plt.plot(x_exact, w_exact, color="blue", linestyle="dashed")
+        plt.xlabel("x [m]")
+        plt.ylabel("Deflection [m]")
+        plt.axis("equal")
+        plt.legend(["GP solution", "Analytical solution"])
+        plt.show()

--- a/gpkit/examples/fuel_burn.py
+++ b/gpkit/examples/fuel_burn.py
@@ -187,8 +187,7 @@ class FuelBurn(Model):
         ]
 
 
-m = FuelBurn()
-sol = m.solve(verbosity=0)
-
 if __name__ == "__main__":
+    m = FuelBurn()
+    sol = m.solve(verbosity=0)
     print(sol.table())

--- a/gpkit/examples/gp_textbook.py
+++ b/gpkit/examples/gp_textbook.py
@@ -145,22 +145,22 @@ class WorkSleep(Model):
 # ---------------------------------------------------------------------------
 # Solve all five and expose individual solutions for testing
 # ---------------------------------------------------------------------------
-m1 = BoxTransport()
-sol1 = m1.solve(verbosity=0)
-
-m2 = FencePlot()
-sol2 = m2.solve(verbosity=0)
-
-m3 = BeamCrossSection()
-sol3 = m3.solve(verbosity=0)
-
-m4 = BoxFromSheet()
-sol4 = m4.solve(verbosity=0)
-
-m5 = WorkSleep()
-sol5 = m5.solve(verbosity=0)
-
 if __name__ == "__main__":
+    m1 = BoxTransport()
+    sol1 = m1.solve(verbosity=0)
+
+    m2 = FencePlot()
+    sol2 = m2.solve(verbosity=0)
+
+    m3 = BeamCrossSection()
+    sol3 = m3.solve(verbosity=0)
+
+    m4 = BoxFromSheet()
+    sol4 = m4.solve(verbosity=0)
+
+    m5 = WorkSleep()
+    sol5 = m5.solve(verbosity=0)
+
     print("=== 1. Box Transport ===")
     print(sol1.summary())
     print("\n=== 2. Fence Plot ===")

--- a/gpkit/examples/growth_allowance.py
+++ b/gpkit/examples/growth_allowance.py
@@ -50,6 +50,7 @@ class Wing(Model):
         ]
 
 
-wing = Wing()
-sol = wing.solve(verbosity=0)
-print(build_budget(sol, wing, wing.m).text())
+if __name__ == "__main__":
+    wing = Wing()
+    sol = wing.solve(verbosity=0)
+    print(build_budget(sol, wing, wing.m).text())

--- a/gpkit/examples/simple_box.py
+++ b/gpkit/examples/simple_box.py
@@ -4,7 +4,7 @@ from gpkit import Model, Var
 
 
 class Box(Model):
-    "Box volume maximization."
+    "Maximize box volume given wall area, floor area, and aspect ratio constraints."
 
     # Parameters
     alpha = Var("-", "lower limit, wall aspect ratio", value=2)

--- a/gpkit/examples/simple_box.py
+++ b/gpkit/examples/simple_box.py
@@ -32,5 +32,6 @@ class Box(Model):
         ]
 
 
-m = Box()
-print(m.solve(verbosity=0).table())
+if __name__ == "__main__":
+    m = Box()
+    print(m.solve(verbosity=0).table())

--- a/gpkit/examples/water_tank.py
+++ b/gpkit/examples/water_tank.py
@@ -4,7 +4,7 @@ from gpkit import Model, Var, VectorVariable
 
 
 class WaterTank(Model):
-    "Rectangular tank surface area minimization."
+    "Minimize surface area of a rectangular tank for a fixed water volume."
 
     M = Var("kg", "mass of water", value=100)
     rho = Var("kg/m^3", "density of water", value=1000)

--- a/gpkit/examples/water_tank.py
+++ b/gpkit/examples/water_tank.py
@@ -22,6 +22,7 @@ class WaterTank(Model):
         ]
 
 
-m = WaterTank()
-sol = m.solve(verbosity=0)
-print(sol.summary())
+if __name__ == "__main__":
+    m = WaterTank()
+    sol = m.solve(verbosity=0)
+    print(sol.summary())

--- a/gpkit/tests/conftest.py
+++ b/gpkit/tests/conftest.py
@@ -1,6 +1,7 @@
 """Pytest configuration and fixtures for gpkit tests"""
 
 import importlib
+import io
 import os
 import sys
 
@@ -17,16 +18,6 @@ def assert_logtol(first, second, logtol=1e-6):
     np.testing.assert_allclose(
         np.log(mag(first)), np.log(mag(second)), atol=logtol, rtol=0
     )
-
-
-class NullFile:
-    "A fake file interface that does nothing"
-
-    def write(self, string):
-        "Do not write, do not pass go."
-
-    def close(self):
-        "Having not written, cease."
 
 
 class NewDefaultSolver:
@@ -47,25 +38,23 @@ class NewDefaultSolver:
 
 
 class StdoutCaptured:
-    "Puts everything that would have printed to stdout in a log file instead"
+    "Captures stdout; writes to logfilepath only when non-empty."
 
     def __init__(self, logfilepath=None):
         self.logfilepath = logfilepath
         self.original_stdout = None
+        self._buf = io.StringIO()
 
     def __enter__(self):
-        "Capture stdout"
         self.original_stdout = sys.stdout
-        sys.stdout = (
-            open(self.logfilepath, mode="w", encoding="utf-8")
-            if self.logfilepath
-            else NullFile()
-        )
+        sys.stdout = self._buf
 
     def __exit__(self, *args):
-        "Return stdout"
-        sys.stdout.close()
         sys.stdout = self.original_stdout
+        content = self._buf.getvalue()
+        if self.logfilepath and content:
+            with open(self.logfilepath, "w", encoding="utf-8") as f:
+                f.write(content)
 
 
 @pytest.fixture(name="solver", params=settings["installed_solvers"])

--- a/gpkit/tests/test_catalog.py
+++ b/gpkit/tests/test_catalog.py
@@ -1,4 +1,4 @@
-"""Catalog-driven smoke test: every registered model must default() and solve.
+"""Catalog smoke test: every registered model must build, solve, and match cost.
 
 Public API (importable by other repos):
   load_catalog(start)       — load models list from catalog.toml nearest to `start`
@@ -12,11 +12,13 @@ from pathlib import Path
 
 import pytest
 
+from gpkit.util.small_scripts import mag
+
 
 def _find_catalog(start):
     """Walk up from `start` to find catalog.toml."""
     p = Path(start).resolve().parent
-    for _ in range(3):
+    for _ in range(4):
         candidate = p / "catalog.toml"
         if candidate.exists():
             return candidate
@@ -32,24 +34,32 @@ def load_catalog(start):
 
 def catalog_ids(models):
     """Return pytest parametrize IDs for a list of catalog model entries."""
-    return [f"{m['module']}:{m['class']}" for m in models]
+    return [m.get("id", f"{m['module']}:{m['class']}") for m in models]
 
 
 def run_catalog_test(model_entry):
-    """Each catalog entry must: import, default(), and solve without exception."""
+    """Each catalog entry must: import, build, and solve. Assert cost if provided."""
     mod = importlib.import_module(model_entry["module"])
     cls = getattr(mod, model_entry["class"])
 
-    m = cls.default()
+    if hasattr(cls, "default"):
+        m = cls.default()
+    else:
+        m = cls()
 
     assert m.cost is not None, (
-        f"{cls.__name__}.default() did not set self.cost. "
-        "default() must return a model with cost assigned."
+        f"{cls.__name__} did not set self.cost. " "setup() must assign self.cost."
     )
 
     sol = m.solve(verbosity=0) if m.is_gp() else m.localsolve(verbosity=0)
-
     assert sol is not None
+
+    if "expected_cost" in model_entry:
+        tol = model_entry.get("expected_cost_tol", 0.01)
+        assert mag(sol.cost) == pytest.approx(model_entry["expected_cost"], rel=tol), (
+            f"{cls.__name__} cost {mag(sol.cost):.6g} does not match "
+            f"expected {model_entry['expected_cost']} (rel tol {tol})"
+        )
 
 
 try:
@@ -60,5 +70,5 @@ except FileNotFoundError:
 
 @pytest.mark.parametrize("model_entry", _CATALOG, ids=catalog_ids(_CATALOG))
 def test_catalog_model(model_entry):
-    """Each catalog entry must: import, default(), and solve without exception."""
+    """Each catalog entry must: import, build, and solve. Assert cost if provided."""
     run_catalog_test(model_entry)

--- a/gpkit/tests/test_catalog.py
+++ b/gpkit/tests/test_catalog.py
@@ -10,9 +10,22 @@ import importlib
 import tomllib
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from gpkit.util.small_scripts import mag
+
+# Expected (cost, rel_tol) for each gpkit-core catalog entry by id.
+# External repos using run_catalog_test can put expected_cost/expected_cost_tol
+# directly in their catalog.toml entries instead.
+_EXPECTED_COSTS = {
+    "box": (0.003674, 0.01),
+    "water_tank": (1.293, 0.01),
+    "beam": (0.7825, 0.001),
+    "fuel_burn": (7561.15, 0.01),
+    "wing": (35.64, 0.001),
+    "bemt_hover": (43582.47, 0.01),
+}
 
 
 def _find_catalog(start):
@@ -42,10 +55,7 @@ def run_catalog_test(model_entry):
     mod = importlib.import_module(model_entry["module"])
     cls = getattr(mod, model_entry["class"])
 
-    if hasattr(cls, "default"):
-        m = cls.default()
-    else:
-        m = cls()
+    m = cls.default()
 
     assert m.cost is not None, (
         f"{cls.__name__} did not set self.cost. " "setup() must assign self.cost."
@@ -53,13 +63,26 @@ def run_catalog_test(model_entry):
 
     sol = m.solve(verbosity=0) if m.is_gp() else m.localsolve(verbosity=0)
     assert sol is not None
+    for val in sol.primal.values():
+        assert not np.isnan(
+            np.atleast_1d(mag(val))
+        ).any(), f"{cls.__name__}: NaN in solution"
 
+    # expected_cost in the catalog entry takes precedence (for external repos);
+    # fall back to the built-in table for gpkit-core entries.
     if "expected_cost" in model_entry:
+        expected = model_entry["expected_cost"]
         tol = model_entry.get("expected_cost_tol", 0.01)
-        assert mag(sol.cost) == pytest.approx(model_entry["expected_cost"], rel=tol), (
-            f"{cls.__name__} cost {mag(sol.cost):.6g} does not match "
-            f"expected {model_entry['expected_cost']} (rel tol {tol})"
-        )
+    else:
+        entry = _EXPECTED_COSTS.get(model_entry.get("id"))
+        if entry is None:
+            return
+        expected, tol = entry
+
+    assert mag(sol.cost) == pytest.approx(expected, rel=tol), (
+        f"{cls.__name__} cost {mag(sol.cost):.6g} does not match "
+        f"expected {expected} (rel tol {tol})"
+    )
 
 
 try:

--- a/gpkit/tests/test_examples.py
+++ b/gpkit/tests/test_examples.py
@@ -139,11 +139,6 @@ class TestExamples:
     def test_gettingstarted(self, example):
         assert example.sol.cost == pytest.approx(1.414, rel=1e-2)
 
-    def test_growth_allowance(self, example):
-        # Spar leaf: rho*t*A = 2700 * 0.005 * 1.0 = 13.5 kg per spar
-        # Spar.m = 1.20 * 13.5 = 16.2; Wing.m = 1.10 * 2 * 16.2 = 35.64
-        assert mag(example.sol.cost) == pytest.approx(35.64, rel=1e-3)
-
     def test_loose_constraintsets(self, example):
         m = example.m
         sol = m.solve(verbosity=0)
@@ -279,19 +274,8 @@ class TestExamples:
     def test_simple_sp(self, example):
         assert example.sol.cost == pytest.approx(0.9, rel=1e-2)
 
-    def test_simple_box(self, example):
-        sol = example.m.solve(verbosity=0)
-        assert sol.cost == pytest.approx(0.003674, rel=1e-2)
-
     def test_x_greaterthan_1(self, example):
         assert example.sol.cost == pytest.approx(1.0, rel=1e-2)
-
-    def test_beam(self, example):
-        assert not np.isnan(example.sol["w"]).any()
-        assert example.sol.cost == pytest.approx(1.6214, rel=1e-3)
-
-    def test_water_tank(self, example):
-        assert example.sol.cost == pytest.approx(1.293, rel=1e-2)
 
     def test_sin_approx_example(self, example):
         sol = example.m.solve(verbosity=0)
@@ -349,15 +333,3 @@ class TestExamples:
     def test_bemt_hover(self, example):
         # Minimum induced power for a 5-bin BEMT rotor at 1e4 N vehicle weight
         assert example.sol.cost == pytest.approx(43582.47, rel=1e-2)
-
-    def test_gp_textbook(self, example):
-        # Five classic textbook GP problems; assert all five costs
-        assert example.sol1.cost == pytest.approx(100.0, rel=1e-2)  # BoxTransport
-        assert example.sol2.cost == pytest.approx(8.0, rel=1e-2)  # FencePlot
-        assert example.sol3.cost == pytest.approx(0.1925, rel=1e-2)  # BeamCrossSection
-        assert example.sol4.cost == pytest.approx(13.5, rel=1e-2)  # BoxFromSheet
-        assert example.sol5.cost == pytest.approx(0.009006, rel=1e-2)  # WorkSleep
-
-    def test_fuel_burn(self, example):
-        # Multi-point aircraft fuel burn minimization (total W_fuel, 3 conditions)
-        assert example.sol.cost == pytest.approx(7561.15, rel=1e-2)

--- a/gpkit/tests/test_examples.py
+++ b/gpkit/tests/test_examples.py
@@ -330,6 +330,11 @@ class TestExamples:
     def test_unbounded(self, example):
         assert example.sol.cost == pytest.approx(1e-30, rel=1e-2)
 
+    def test_beam(self, example):
+        b = example.Beam.default()
+        sol = b.solve(verbosity=0)
+        assert not np.isnan(sol["w"]).any()
+
     def test_bemt_hover(self, example):
         # Minimum induced power for a 5-bin BEMT rotor at 1e4 N vehicle weight
         assert example.sol.cost == pytest.approx(43582.47, rel=1e-2)

--- a/gpkit/tests/test_examples.py
+++ b/gpkit/tests/test_examples.py
@@ -333,3 +333,21 @@ class TestExamples:
     def test_bemt_hover(self, example):
         # Minimum induced power for a 5-bin BEMT rotor at 1e4 N vehicle weight
         assert example.sol.cost == pytest.approx(43582.47, rel=1e-2)
+
+    def test_gp_textbook(self, example):
+        # Five classical GP textbook problems; solves run directly on classes
+        assert example.BoxTransport().solve(verbosity=0).cost == pytest.approx(
+            100.0, rel=1e-2
+        )
+        assert example.FencePlot().solve(verbosity=0).cost == pytest.approx(
+            8.0, rel=1e-2
+        )
+        assert example.BeamCrossSection().solve(verbosity=0).cost == pytest.approx(
+            0.1925, rel=1e-2
+        )
+        assert example.BoxFromSheet().solve(verbosity=0).cost == pytest.approx(
+            13.5, rel=1e-2
+        )
+        assert example.WorkSleep().solve(verbosity=0).cost == pytest.approx(
+            0.009006, rel=1e-2
+        )

--- a/scripts/regen_examples.py
+++ b/scripts/regen_examples.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Regenerate output files for catalog-eligible examples.
+
+Reads catalog.toml to discover which gpkit.examples.* scripts to run (no
+hardcoded list). Captures each script's stdout to
+docs/source/examples/{name}_output.txt.
+
+Non-catalog examples (autosweep, simpleflight, etc.) still have top-level
+execution code; their output is captured by the conftest _import_example
+fixture during pytest — no separate script needed for them.
+
+Usage:
+    uv run python scripts/regen_examples.py
+"""
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+EXAMPLES_DIR = REPO_ROOT / "gpkit" / "examples"
+OUTPUT_DIR = REPO_ROOT / "docs" / "source" / "examples"
+CATALOG_PATH = REPO_ROOT / "catalog.toml"
+
+_EXAMPLES_PREFIX = "gpkit.examples."
+
+
+def _catalog_scripts():
+    """Deduplicated list of example script stems registered in catalog.toml."""
+    with open(CATALOG_PATH, "rb") as f:
+        data = tomllib.load(f)
+    seen: set[str] = set()
+    stems: list[str] = []
+    for entry in data.get("models", []):
+        mod = entry.get("module", "")
+        if mod.startswith(_EXAMPLES_PREFIX):
+            stem = mod[len(_EXAMPLES_PREFIX) :]
+            if stem not in seen:
+                seen.add(stem)
+                stems.append(stem)
+    return stems
+
+
+def main():
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    scripts = _catalog_scripts()
+    failed = []
+    for name in scripts:
+        script = EXAMPLES_DIR / f"{name}.py"
+        if not script.exists():
+            print(f"  SKIP {name} (script not found)")
+            continue
+        out_file = OUTPUT_DIR / f"{name}_output.txt"
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            print(f"  FAIL {name}:\n{result.stderr}")
+            failed.append(name)
+        else:
+            out_file.write_text(result.stdout)
+            lines = result.stdout.count("\n")
+            print(f"  OK   {name} → {out_file.relative_to(REPO_ROOT)} ({lines} lines)")
+
+    if failed:
+        print(
+            f"\n{len(failed)} example(s) failed: {', '.join(failed)}", file=sys.stderr
+        )
+        sys.exit(1)
+    print(f"\n{len(scripts) - len(failed)} catalog example(s) regenerated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/regen_examples.py
+++ b/scripts/regen_examples.py
@@ -60,6 +60,9 @@ def main():
         if result.returncode != 0:
             print(f"  FAIL {name}:\n{result.stderr}")
             failed.append(name)
+        elif not result.stdout:
+            print(f"  WARN {name}: produced no output, skipping write")
+            failed.append(name)
         else:
             out_file.write_text(result.stdout)
             lines = result.stdout.count("\n")


### PR DESCRIPTION
Examples now importable without side effects — moved all module-level execution in beam.py,
  fuel_burn.py, gp_textbook.py, growth_allowance.py, simple_box.py, and water_tank.py into `if __name__ ==
   "__main__":` blocks
  - catalog.toml restructured — entries now carry only id/module/class; added bemt_hover; dropped the
  five gp_textbook classes as catalog entries
  - test_catalog.py hardened — expected costs moved from catalog into a _EXPECTED_COSTS table in code;
  added a NaN check over all primal values after every solve; external repos can still put expected_cost
  directly in their catalog entries
  - test_examples.py updated — removed individual cost-assertion tests for models now covered by the
  catalog; restored test_gp_textbook to directly instantiate and solve the five textbook classes
  - conftest.py simplified — StdoutCaptured now captures to io.StringIO and only writes to disk when
  output is non-empty; NullFile deleted
  - scripts/regen_examples.py added — reads catalog.toml and regenerates
  docs/source/examples/*_output.txt for each catalog example; fails if any example errors or produces no
  output
  - make examples target added — replaces regen-examples; make test no longer depends on it
  - CI updated — make examples runs before make coverage; make check-clean afterwards catches any output
  drift