### PR TITLE
various small fixes

### DIFF
--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -1,6 +1,6 @@
 "GP and SP modeling package"
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"
 
 import numpy as _np
 

--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -96,7 +96,7 @@ class Model(CostedConstraintSet):  # pylint: disable=too-many-instance-attribute
             elif isinstance(items, dict):
                 for item in items.values():
                     _scan_for_children(item)
-            elif isinstance(items, list):
+            elif isinstance(items, (list, tuple)):
                 for item in items:
                     _scan_for_children(item)
 

--- a/gpkit/report.py
+++ b/gpkit/report.py
@@ -47,7 +47,7 @@ class CGroup:
     """A named constraint group within a report section."""
 
     label: str  # "" for unnamed groups
-    constraints: list  # raw constraint objects; to_dict() serializes via str()
+    constraints: list  # raw constraint objects; str_without() or str() fallback
 
 
 @dataclass
@@ -95,7 +95,10 @@ class ReportSection:  # pylint: disable=too-many-instance-attributes
             return [
                 {
                     "label": cg.label,
-                    "constraints": [c.str_without(excluded) for c in cg.constraints],
+                    "constraints": [
+                        c.str_without(excluded) if hasattr(c, "str_without") else str(c)
+                        for c in cg.constraints
+                    ],
                 }
                 for cg in self.constraint_groups
             ]
@@ -344,7 +347,7 @@ def _build_constraint_groups(model) -> List[CGroup]:
             CGroup(
                 label=label,
                 constraints=_collect_leaf_constraints(
-                    items if isinstance(items, list) else [items]
+                    items if isinstance(items, (list, tuple)) else [items]
                 ),
             )
             for label, items in model.cgroups.items()

--- a/gpkit/report.py
+++ b/gpkit/report.py
@@ -86,6 +86,20 @@ class ReportSection:  # pylint: disable=too-many-instance-attributes
     objective_units: str = ""  # unit string for the cost expression
     objective_direction: str = "minimize"  # "minimize" or "maximize"
 
+    def _render_constraint_groups(self) -> list:
+        """Render constraint groups using the same lineage context as the text path."""
+        excluded = {"units"}
+        if self.magic_prefix:
+            excluded.add(":MAGIC:" + self.magic_prefix)
+        with lineage_display_context(self.lineage_map):
+            return [
+                {
+                    "label": cg.label,
+                    "constraints": [c.str_without(excluded) for c in cg.constraints],
+                }
+                for cg in self.constraint_groups
+            ]
+
     def to_dict(self) -> dict:
         """JSON-serializable dict (for format='dict' and future API)."""
         return {
@@ -106,10 +120,7 @@ class ReportSection:  # pylint: disable=too-many-instance-attributes
             "objective_units": self.objective_units,
             "free_variables": [v.to_dict() for v in self.free_variables],
             "fixed_variables": [v.to_dict() for v in self.fixed_variables],
-            "constraint_groups": [
-                {"label": cg.label, "constraints": [str(c) for c in cg.constraints]}
-                for cg in self.constraint_groups
-            ],
+            "constraint_groups": self._render_constraint_groups(),
             "children": [c.to_dict() for c in self.children],
         }
 

--- a/gpkit/tests/test_report.py
+++ b/gpkit/tests/test_report.py
@@ -129,8 +129,8 @@ class TestReportDataclasses:
 
         class _AbbrParent(Model):
             def setup(self):
-                self.child = _AbbrChild()
-                return [self.child]
+                child = _AbbrChild()
+                return [child]
 
         class _AbbrChild(Model):
             def setup(self):

--- a/gpkit/tests/test_report.py
+++ b/gpkit/tests/test_report.py
@@ -109,6 +109,42 @@ class TestReportDataclasses:
         assert restored["free_variables"][0]["name"] == "x"
         assert restored["constraint_groups"][0]["label"] == "Aero"
 
+    def test_to_dict_non_constraint_object_in_cgroup(self):
+        """to_dict() falls back to str() for objects without str_without()."""
+        cg = CGroup(label="Raw", constraints=[("x", ">=", "1")])
+        rs = ReportSection(
+            title="T",
+            description="",
+            assumptions=[],
+            free_variables=[],
+            fixed_variables=[],
+            constraint_groups=[cg],
+            children=[],
+        )
+        d = rs.to_dict()
+        assert d["constraint_groups"][0]["constraints"] == ["('x', '>=', '1')"]
+
+    def test_to_dict_constraint_names_abbreviated_by_lineage(self):
+        """to_dict() abbreviates variable names via magic_prefix like text renderer."""
+
+        class _AbbrParent(Model):
+            def setup(self):
+                self.child = _AbbrChild()
+                return [self.child]
+
+        class _AbbrChild(Model):
+            def setup(self):
+                x = Variable("x_abbr")
+                return {"group": [x >= 1]}
+
+        m = _AbbrParent()
+        ir = build_report_ir(m)
+        child_ir = ir.children[0]
+        d = child_ir.to_dict()
+        cg = d["constraint_groups"][0]
+        # Variable name should not carry the child's own prefix
+        assert all("_AbbrChild" not in s for s in cg["constraints"])
+
 
 # ── build_report_ir() ────────────────────────────────────────────────────────
 

--- a/gpkit/tests/test_report.py
+++ b/gpkit/tests/test_report.py
@@ -88,7 +88,8 @@ class TestReportDataclasses:
         ve = VarEntry(
             name="x", latex="x", value=2.0, sensitivity=0.1, units="m", label="span"
         )
-        cg = CGroup(label="Aero", constraints=[("x", ">=", "1")])
+        x_test = Variable("x_to_dict_test")
+        cg = CGroup(label="Aero", constraints=[x_test >= 1])
         rs = ReportSection(
             title="Fuselage",
             description="fuselage drag model",


### PR DESCRIPTION
  - Tuples as model lists: `setup()` can now return a tuple of constraints/models in addition to a list;
  - `_scan_for_children` and `_build_constraint_groups` both handle tuples uniformly.
  - `fmt="dict"` constraint rendering: constraint strings in `to_dict()` now use `str_without()` (with lineage
  context and magic-prefix stripping), matching the text and markdown renderers. Falls back to str() for
  non-constraint objects.
  - Version bump: 0.3.7 → 0.3.8.