### PR TITLE
various IR and test cleanups

### DIFF
--- a/catalog.toml
+++ b/catalog.toml
@@ -31,8 +31,3 @@ class = "Wing"
 id = "bemt_hover"
 module = "gpkit.examples.bemt_hover"
 class = "BEMTHover"
-
-[[models]]
-id = "bemt_hover"
-module = "gpkit.examples.bemt_hover"
-class = "BEMTHover"

--- a/docs/source/examples/bemt_hover_output.txt
+++ b/docs/source/examples/bemt_hover_output.txt
@@ -39,25 +39,25 @@ BEMTHover.P : 4.358e+04 [W]
 Solution
 --------
 BEMTHover
-          A : 201.1     [m²]           disk area
-      Omega : 16.73     [rpm]          rotor RPM
-          P : 4.358e+04 [W]            total induced power
-          R : 8         [m]            rotor radius
-     V_i[:] : [ 4.62      4.41      4.41      4.41      3.95     ] [m/s] induced velocity
-\Delta r[:] : [ 0.435     0.177     0.139     0.119     0.13     ]       non-dimensional radius step
-    dC_P[:] : [ 0.0136    0.0129    0.0129    0.0129    0.0116   ]       incremental power coefficient
-    dC_T[:] : [ 0.0412    0.0412    0.0412    0.0412    0.0412   ]       incremental thrust coefficient
-      dP[:] : [ 9.24e+03  8.82e+03  8.82e+03  8.82e+03  7.89e+03 ] [W]   incremental power
-       r[:] : [ 0.218     0.589     0.747     0.876     1        ]       non-dimensional radius
+         A : 201.1     [m²]           disk area
+     Omega : 16.73     [rpm]          rotor RPM
+         P : 4.358e+04 [W]            total induced power
+         R : 8         [m]            rotor radius
+Delta_r[:] : [ 0.435     0.177     0.139     0.119     0.13     ]       non-dimensional radius step
+    V_i[:] : [ 4.62      4.41      4.41      4.41      3.95     ] [m/s] induced velocity
+   dC_P[:] : [ 0.0136    0.0129    0.0129    0.0129    0.0116   ]       incremental power coefficient
+   dC_T[:] : [ 0.0412    0.0412    0.0412    0.0412    0.0412   ]       incremental thrust coefficient
+     dP[:] : [ 9.24e+03  8.82e+03  8.82e+03  8.82e+03  7.89e+03 ] [W]   incremental power
+      r[:] : [ 0.218     0.589     0.747     0.876     1        ]       non-dimensional radius
 ...constants
-      R_max : 8         [m]     (-1)   maximum rotor radius
-        rho : 1.23      [kg/m³] (-0.5) air density
-     dr_min : 0.001             (~0)   minimum bin width (non-dimensional)
-  Omega_max : 280       [rpm]   (~0)   maximum rotor RPM
-  Omega_min : 1         [rpm]   (~0)   minimum rotor RPM
-      R_min : 0.1       [m]     (~0)   minimum rotor radius
-     \xi[:] : [ 2e+03   2e+03   2e+03   2e+03   2e+03  ] [N]   thrust per bin (fixed)
-         sens ( +0.318  +0.303  +0.303  +0.303  +0.272 )
+     R_max : 8         [m]     (-1)   maximum rotor radius
+       rho : 1.23      [kg/m³] (-0.5) air density
+    dr_min : 0.001             (~0)   minimum bin width (non-dimensional)
+ Omega_max : 280       [rpm]   (~0)   maximum rotor RPM
+ Omega_min : 1         [rpm]   (~0)   minimum rotor RPM
+     R_min : 0.1       [m]     (~0)   minimum rotor radius
+     xi[:] : [ 2e+03   2e+03   2e+03   2e+03   2e+03  ] [N]   thrust per bin (fixed)
+        sens ( +0.318  +0.303  +0.303  +0.303  +0.272 )
 
 Most Sensitive Constraints
 --------------------------
@@ -66,28 +66,28 @@ BEMTHover
 +1      : R ≤ R_max
 +0.5134 : r[4] ≤ 1
 +0.5    : A = 3.14·R²
-+0.4866 : \Delta r[:].sum() ≤ 1
-+0.4228 : r[4] ≥ r[3] + 0.5·\Delta r[3] + 0.5·\Delta r[4]
--0.3179 : V_i[0]²·r[0]·\Delta r[0]/(dC_T[0]·(Omega·R)²) = 0.25
-+0.3179 : \xi[0] = rho·A·(Omega·R)²·dC_T[0]
--0.3035 : V_i[1]²·r[1]·\Delta r[1]/(dC_T[1]·(Omega·R)²) = 0.25
-+0.3035 : \xi[1] = rho·A·(Omega·R)²·dC_T[1]
--0.3035 : V_i[2]²·r[2]·\Delta r[2]/(dC_T[2]·(Omega·R)²) = 0.25
-+0.3035 : \xi[2] = rho·A·(Omega·R)²·dC_T[2]
--0.3035 : V_i[3]²·r[3]·\Delta r[3]/(dC_T[3]·(Omega·R)²) = 0.25
-+0.3035 : \xi[3] = rho·A·(Omega·R)²·dC_T[3]
--0.2717 : V_i[4]²·r[4]·\Delta r[4]/(dC_T[4]·(Omega·R)²) = 0.25
-+0.2717 : \xi[4] = rho·A·(Omega·R)²·dC_T[4]
-+0.2691 : r[3] ≥ r[2] + 0.5·\Delta r[2] + 0.5·\Delta r[3]
-+0.2119 : V_i[0]³·r[0]·\Delta r[0]/(dC_P[0]·(Omega·R)³) = 0.25
++0.4866 : Delta_r[:].sum() ≤ 1
++0.4228 : r[4] ≥ r[3] + 0.5·Delta_r[3] + 0.5·Delta_r[4]
+-0.3179 : V_i[0]²·r[0]·Delta_r[0]/(dC_T[0]·(Omega·R)²) = 0.25
++0.3179 : xi[0] = rho·A·(Omega·R)²·dC_T[0]
+-0.3035 : V_i[1]²·r[1]·Delta_r[1]/(dC_T[1]·(Omega·R)²) = 0.25
++0.3035 : xi[1] = rho·A·(Omega·R)²·dC_T[1]
+-0.3035 : V_i[2]²·r[2]·Delta_r[2]/(dC_T[2]·(Omega·R)²) = 0.25
++0.3035 : xi[2] = rho·A·(Omega·R)²·dC_T[2]
+-0.3035 : V_i[3]²·r[3]·Delta_r[3]/(dC_T[3]·(Omega·R)²) = 0.25
++0.3035 : xi[3] = rho·A·(Omega·R)²·dC_T[3]
+-0.2717 : V_i[4]²·r[4]·Delta_r[4]/(dC_T[4]·(Omega·R)²) = 0.25
++0.2717 : xi[4] = rho·A·(Omega·R)²·dC_T[4]
++0.2691 : r[3] ≥ r[2] + 0.5·Delta_r[2] + 0.5·Delta_r[3]
++0.2119 : V_i[0]³·r[0]·Delta_r[0]/(dC_P[0]·(Omega·R)³) = 0.25
 -0.2119 : dP[0] = rho·A·(Omega·R)³·dC_P[0]
-+0.2023 : V_i[1]³·r[1]·\Delta r[1]/(dC_P[1]·(Omega·R)³) = 0.25
++0.2023 : V_i[1]³·r[1]·Delta_r[1]/(dC_P[1]·(Omega·R)³) = 0.25
 -0.2023 : dP[1] = rho·A·(Omega·R)³·dC_P[1]
-+0.2023 : V_i[2]³·r[2]·\Delta r[2]/(dC_P[2]·(Omega·R)³) = 0.25
++0.2023 : V_i[2]³·r[2]·Delta_r[2]/(dC_P[2]·(Omega·R)³) = 0.25
 -0.2023 : dP[2] = rho·A·(Omega·R)³·dC_P[2]
-+0.2023 : V_i[3]³·r[3]·\Delta r[3]/(dC_P[3]·(Omega·R)³) = 0.25
++0.2023 : V_i[3]³·r[3]·Delta_r[3]/(dC_P[3]·(Omega·R)³) = 0.25
 -0.2023 : dP[3] = rho·A·(Omega·R)³·dC_P[3]
-+0.1811 : V_i[4]³·r[4]·\Delta r[4]/(dC_P[4]·(Omega·R)³) = 0.25
++0.1811 : V_i[4]³·r[4]·Delta_r[4]/(dC_P[4]·(Omega·R)³) = 0.25
 -0.1811 : dP[4] = rho·A·(Omega·R)³·dC_P[4]
-+0.1283 : r[2] ≥ r[1] + 0.5·\Delta r[1] + 0.5·\Delta r[2]
-+0.106  : r[0] = \Delta r[0]/2
++0.1283 : r[2] ≥ r[1] + 0.5·Delta_r[1] + 0.5·Delta_r[2]
++0.106  : r[0] = Delta_r[0]/2

--- a/gpkit/ast_nodes.py
+++ b/gpkit/ast_nodes.py
@@ -207,7 +207,10 @@ def ast_from_ir(ir_dict, var_registry):
     if node == "slice":
         return slice(ir_dict.get("start"), ir_dict.get("stop"), ir_dict.get("step"))
     if node == "tuple":
-        return tuple(ast_from_ir(el, var_registry) for el in ir_dict["items"])
+        return tuple(
+            ast_from_ir(el, var_registry) if isinstance(el, dict) else el
+            for el in ir_dict["items"]
+        )
     raise ValueError(f"Unknown AST IR node type: {node}")
 
 

--- a/gpkit/ast_nodes.py
+++ b/gpkit/ast_nodes.py
@@ -181,6 +181,40 @@ def _list_from_ir(items, var_registry):
     return [ast_from_ir(c, var_registry) if isinstance(c, dict) else c for c in items]
 
 
+def _ast_from_ir_var(d, reg):
+    return VarNode(reg[d["ref"]])
+
+
+def _ast_from_ir_const(d, _reg):
+    return ConstNode(d["value"])
+
+
+def _ast_from_ir_pi(_d, _reg):
+    return PiNode()
+
+
+def _ast_from_ir_expr(d, reg):
+    return ExprNode(d["op"], tuple(_list_from_ir(d["children"], reg)))
+
+
+def _ast_from_ir_slice(d, _reg):
+    return slice(d.get("start"), d.get("stop"), d.get("step"))
+
+
+def _ast_from_ir_tuple(d, reg):
+    return tuple(_list_from_ir(d["items"], reg))
+
+
+_AST_NODE_BUILDERS = {
+    "var": _ast_from_ir_var,
+    "const": _ast_from_ir_const,
+    "pi": _ast_from_ir_pi,
+    "expr": _ast_from_ir_expr,
+    "slice": _ast_from_ir_slice,
+    "tuple": _ast_from_ir_tuple,
+}
+
+
 def ast_from_ir(ir_dict, var_registry):
     """Reconstruct an AST node from its IR dict.
 
@@ -194,21 +228,10 @@ def ast_from_ir(ir_dict, var_registry):
     if not isinstance(ir_dict, dict):
         assert var_registry is None
         return ir_dict  # raw number passthrough (e.g., exponent in pow)
-    node = ir_dict["node"]
-    if node == "var":
-        return VarNode(var_registry[ir_dict["ref"]])
-    if node == "const":
-        return ConstNode(ir_dict["value"])
-    if node == "pi":
-        return PiNode()
-    if node == "expr":
-        children = _list_from_ir(ir_dict["children"], var_registry)
-        return ExprNode(ir_dict["op"], tuple(children))
-    if node == "slice":
-        return slice(ir_dict.get("start"), ir_dict.get("stop"), ir_dict.get("step"))
-    if node == "tuple":
-        return tuple(_list_from_ir(ir_dict["items"], var_registry))
-    raise ValueError(f"Unknown AST IR node type: {node}")
+    builder = _AST_NODE_BUILDERS.get(ir_dict["node"])
+    if builder is None:
+        raise ValueError(f"Unknown AST IR node type: {ir_dict['node']}")
+    return builder(ir_dict, var_registry)
 
 
 def to_ast(obj):

--- a/gpkit/ast_nodes.py
+++ b/gpkit/ast_nodes.py
@@ -158,6 +158,15 @@ def _child_to_ir(child):
         return child.to_ir()
     if isinstance(child, (int, float)):
         return child
+    if isinstance(child, slice):
+        return {
+            "node": "slice",
+            "start": child.start,
+            "stop": child.stop,
+            "step": child.step,
+        }
+    if isinstance(child, tuple):
+        return {"node": "tuple", "items": [_child_to_ir(el) for el in child]}
     # numpy scalars and similar numeric types
     try:
         return float(child)
@@ -195,6 +204,10 @@ def ast_from_ir(ir_dict, var_registry):
             else:
                 children.append(c)  # raw number
         return ExprNode(ir_dict["op"], tuple(children))
+    if node == "slice":
+        return slice(ir_dict.get("start"), ir_dict.get("stop"), ir_dict.get("step"))
+    if node == "tuple":
+        return tuple(ast_from_ir(el, var_registry) for el in ir_dict["items"])
     raise ValueError(f"Unknown AST IR node type: {node}")
 
 

--- a/gpkit/ast_nodes.py
+++ b/gpkit/ast_nodes.py
@@ -176,6 +176,11 @@ def _child_to_ir(child):
         ) from exc
 
 
+def _list_from_ir(items, var_registry):
+    "Deserialize a list of AST children: dicts recurse, raw values pass through."
+    return [ast_from_ir(c, var_registry) if isinstance(c, dict) else c for c in items]
+
+
 def ast_from_ir(ir_dict, var_registry):
     """Reconstruct an AST node from its IR dict.
 
@@ -197,20 +202,12 @@ def ast_from_ir(ir_dict, var_registry):
     if node == "pi":
         return PiNode()
     if node == "expr":
-        children = []
-        for c in ir_dict["children"]:
-            if isinstance(c, dict):
-                children.append(ast_from_ir(c, var_registry))
-            else:
-                children.append(c)  # raw number
+        children = _list_from_ir(ir_dict["children"], var_registry)
         return ExprNode(ir_dict["op"], tuple(children))
     if node == "slice":
         return slice(ir_dict.get("start"), ir_dict.get("stop"), ir_dict.get("step"))
     if node == "tuple":
-        return tuple(
-            ast_from_ir(el, var_registry) if isinstance(el, dict) else el
-            for el in ir_dict["items"]
-        )
+        return tuple(_list_from_ir(ir_dict["items"], var_registry))
     raise ValueError(f"Unknown AST IR node type: {node}")
 
 

--- a/gpkit/examples/bemt_hover.py
+++ b/gpkit/examples/bemt_hover.py
@@ -51,7 +51,7 @@ class BEMTHover(Model):
             # Thrust per bin: fixed to equal share of vehicle weight
             xi = Variable("xi", W_vehicle / N, "N", "thrust per bin (fixed)")
             r = Variable("r", "-", "non-dimensional radius")
-            dr = Variable("dr", "-", "non-dimensional radius step")
+            dr = Variable("Delta_r", "-", "non-dimensional radius step")
             Vi = Variable("V_i", "m/s", "induced velocity")
             dCT = Variable("dC_T", "-", "incremental thrust coefficient")
             dCP = Variable("dC_P", "-", "incremental power coefficient")

--- a/gpkit/examples/bemt_hover.py
+++ b/gpkit/examples/bemt_hover.py
@@ -49,9 +49,9 @@ class BEMTHover(Model):
         # Per-bin variables (N-element vectors created inside Vectorize context)
         with Vectorize(N):
             # Thrust per bin: fixed to equal share of vehicle weight
-            xi = Variable(r"\xi", W_vehicle / N, "N", "thrust per bin (fixed)")
+            xi = Variable("xi", W_vehicle / N, "N", "thrust per bin (fixed)")
             r = Variable("r", "-", "non-dimensional radius")
-            dr = Variable(r"\Delta r", "-", "non-dimensional radius step")
+            dr = Variable("dr", "-", "non-dimensional radius step")
             Vi = Variable("V_i", "m/s", "induced velocity")
             dCT = Variable("dC_T", "-", "incremental thrust coefficient")
             dCP = Variable("dC_P", "-", "incremental power coefficient")

--- a/gpkit/tests/test_ir.py
+++ b/gpkit/tests/test_ir.py
@@ -21,7 +21,6 @@ from gpkit.ast_nodes import (
 )
 from gpkit.constraints import ArrayConstraint
 from gpkit.constraints.set import build_model_tree
-from gpkit.exceptions import IRSerializationError
 from gpkit.nomials.map import NomialMap
 from gpkit.nomials.math import (
     Monomial,
@@ -742,6 +741,27 @@ class TestConstraintIR:
             assert ir_dict["type"] == "PosynomialInequality"
             assert ir_dict["oper"] == ">="
 
+    def test_slice_in_ast_serializes(self):
+        """Posynomial whose AST contains a slice (e.g. from arr[:j].sum())
+        must round-trip through model to_ir / from_ir without error.
+
+        This pattern appears in vectorized integration constraints like
+        r[j] >= dr[:j].sum() used in BEMTHover and similar models.
+        """
+        from gpkit import Vectorize
+
+        with Vectorize(4):
+            dr = Variable("dr", "-", "bin width")
+
+        x = Variable("x", "-")
+        m = Model(x, [x >= dr[:2].sum()])
+        ir = m.to_ir()
+        # Must be JSON-serializable (the original failure mode)
+        json.dumps(ir)
+        # Round-trip must reconstruct an equivalent solvable model
+        m2 = Model.from_ir(ir)
+        assert len(list(m2)) == len(list(m))
+
     def test_constraint_from_ir_dispatch(self):
         """constraint_from_ir dispatches to the correct class."""
         x = Variable("x")
@@ -1351,18 +1371,11 @@ def test_to_ir_monomial_substitution():
 
 @pytest.mark.parametrize("model_entry", _CORE_CATALOG, ids=catalog_ids(_CORE_CATALOG))
 def test_core_catalog_ir_roundtrip(model_entry):
-    """gpkit-core catalog model: IR must be identical after round-trip.
-
-    If to_ir() itself raises (e.g. BEMTHover slice AST gap), the test is
-    skipped so the gap is visible in CI output without failing.
-    """
+    """gpkit-core catalog model: IR must serialize and round-trip cleanly."""
     mod = importlib.import_module(model_entry["module"])
     cls = getattr(mod, model_entry["class"])
     m = cls.default()
-    try:
-        ir1 = m.to_ir()
-    except IRSerializationError as exc:
-        pytest.skip(f"{cls.__name__}.to_ir() failed (known IR gap): {exc}")
+    ir1 = m.to_ir()
     m2 = Model.from_ir(ir1)
     ir2 = m2.to_ir()
     diff = ir_diff(ir1, ir2)

--- a/gpkit/tests/test_ir.py
+++ b/gpkit/tests/test_ir.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 import gpkit
-from gpkit import Model, SignomialsEnabled, Variable, VarKey, VectorVariable
+from gpkit import Model, SignomialsEnabled, Variable, VarKey, Vectorize, VectorVariable
 from gpkit.ast_nodes import (
     ConstNode,
     ExprNode,
@@ -748,17 +748,24 @@ class TestConstraintIR:
         This pattern appears in vectorized integration constraints like
         r[j] >= dr[:j].sum() used in BEMTHover and similar models.
         """
-        from gpkit import Vectorize
-
         with Vectorize(4):
             dr = Variable("dr", "-", "bin width")
 
         x = Variable("x", "-")
         m = Model(x, [x >= dr[:2].sum()])
         ir = m.to_ir()
-        # Must be JSON-serializable (the original failure mode)
         json.dumps(ir)
-        # Round-trip must reconstruct an equivalent solvable model
+        m2 = Model.from_ir(ir)
+        assert len(list(m2)) == len(list(m))
+
+    def test_tuple_with_integer_index_in_ast_round_trips(self):
+        """2D array indexed with [int, :] produces a tuple child containing a
+        raw integer in the IR. ast_from_ir must not assert on that integer."""
+        a = VectorVariable((2, 3), "a", "-")
+        x = Variable("x", "-")
+        m = Model(x, [x >= a[0, :].sum()])
+        ir = m.to_ir()
+        json.dumps(ir)
         m2 = Model.from_ir(ir)
         assert len(list(m2)) == len(list(m))
 

--- a/gpkit/varkey.py
+++ b/gpkit/varkey.py
@@ -231,6 +231,8 @@ class VarKey(ReprMixin):  # pylint:disable=too-many-instance-attributes
             ir["label"] = self.label
         if self.idx is not None:
             ir["idx"] = list(self.idx)
+            if self.veckey is not None:
+                ir["veckey_ref"] = self.veckey.ref
         if self.shape:
             ir["shape"] = list(self.shape)
         return ir


### PR DESCRIPTION
  - Duplicate bemt_hover catalog entry removed
  - `VarKey.to_ir()` now emits veckey_ref for element keys (links elements to their parent)
  - `_child_to_ir` / `ast_from_ir` handle slice and tuple AST children (general fix for any model using
  `arr[:j].sum()` style constraints)
  - Catalog round-trip test unskipped for bemt_hover; new focused test_slice_in_ast_serializes test added
  - LaTeX variable names removed from bemt_hover.py in favor of auto-generation