### PR TITLE
UAV example clarity improvements

### DIFF
--- a/catalog.toml
+++ b/catalog.toml
@@ -21,6 +21,7 @@ class = "Beam"
 id = "uav"
 module = "gpkit.examples.uav"
 class = "UAV"
+budget_vars = ["W_mto"]
 
 [[models]]
 id = "wing"

--- a/docs/source/examples/uav_output.txt
+++ b/docs/source/examples/uav_output.txt
@@ -1,10 +1,10 @@
 
-          ┃┓                 /
-          ┃┃
-          ┃┃
-          ┃┣╸Outbound.W_fuel /
-          ┃┃ (3,731N)
-     Cost╺┫┛                 /
+          ┃┓                 ┓
+          ┃┃                 ┃
+          ┃┃                 ┃
+          ┃┣╸Outbound.W_fuel ┣╸Outbound.AircraftPerf.W╶⎨
+          ┃┃ (3,731N)        ┃ (34,888N)
+     Cost╺┫┛                 ┛
  (7,105N) ┃┓               ┓           ┓
           ┃┃               ┃           ┃
           ┃┃               ┃           ┣╸W_tilde╶⎨
@@ -33,7 +33,7 @@
      ┃┣╸Aircraft ┛
      ┃┃          ┣╸W_tilde ≥ W_fixed + W_pay + Engine.W
      ┃┛          ┣╸W_zfw ≥ W_tilde + Wing.W
-     ┃┣╸LandingCondition╶⎨
+     ┃┣╸HeavyLandingCase╶⎨
 
 
 Optimal Cost
@@ -92,16 +92,17 @@ UAV.Aircraft.Wing
             r_h : 0.75              (+0.01005) wing strut taper parameter
 sigma_max_shear : 167       [MPa]   (-0.01005) allowable shear stress
 
-UAV.LandingCondition
+UAV.HeavyLandingCase
    V_stall : 38   [m/s]             stall speed
 ...constants
 V_stallmax : 38   [m/s]   (-0.3605) stall speed limit
     rho_sl : 1.23 [kg/m³] (-0.1803) air density, sea level
 
 UAV.Mission
-    R : 5e+06 [m]           mission leg range
+     R : 5e+06 [m]           mission leg range
+W_fuel : 7105  [N]           total fuel weight
 ...constants
-R_min : 5000  [km] (+1.141) minimum range requirement
+ R_min : 5000  [km] (+1.141) minimum range requirement
 
 UAV.Mission.Outbound
 W_fuel : 3731   [N]  fuel weight for this leg
@@ -179,7 +180,7 @@ UAV.Mission.SprintCondition.FlightState
   V : 150      [m/s]                 flight speed
 ...constants
 rho : 0.91     [kg/m³]  (+0.1229)    air density
- mu : 1.69e-05 [kg/m/s] (-0.0002407) dynamic viscosity
+ mu : 1.69e-05 [kg/m/s] (-0.0002408) dynamic viscosity
 
 Most Sensitive Constraints
 --------------------------
@@ -203,15 +204,16 @@ UAV.Aircraft.Wing
 +0.01005 : A·W_tilde·N_lift·q²/(tau·S·t_web·sigma_max_shear) ≤ 12
 +0.01005 : W_web ≥ 8·rho_alum·g·r_h·tau·t_web·S^1.5·nu/(3·A^0.5)
 
-UAV.LandingCondition
+UAV.HeavyLandingCase
 +0.3605 : V_stall ≤ V_stallmax
 +0.1803 : W_mto ≤ 0.5·rho_sl·V_stall²·C_Lmax·S
 
 UAV.Mission
-+1.141  : R ≥ R_min
-+0.7024 : W ≥ W_zfw + W_fuel
-+0.5365 : W ≥ W_zfw
-+0.1803 : W_mto ≥ W + W_fuel
++1.141   : R ≥ R_min
++0.5395  : W ≥ W_zfw + W_fuel
++0.5365  : W ≥ W_zfw
++0.1803  : W_mto ≥ W_zfw + W_fuel
++0.03316 : W_fuel ≥ W_fuel + W_fuel
 
 UAV.Mission.Outbound
 +0.5706 : z_bre ≥ g·R·T/(h_fuel·eta_0·W)
@@ -220,7 +222,7 @@ UAV.Mission.Outbound
 UAV.Mission.Outbound.AircraftPerf
 +0.6211 : C_D ≥ CDA0/S + C_Dp + C_Di
 +0.6211 : T ≥ 0.5·rho·C_D·S·V²
-+0.5648 : W = 0.5·rho·C_L·S·V²
++0.5648 : W ≤ 0.5·rho·C_L·S·V²
 +0.2715 : C_Di ≥ C_L²/(π·e·A)
 
 UAV.Mission.Outbound.AircraftPerf.PropulsionPerf
@@ -239,7 +241,7 @@ UAV.Mission.Return
 UAV.Mission.Return.AircraftPerf
 +0.6215 : C_D ≥ CDA0/S + C_Dp + C_Di
 +0.6215 : T ≥ 0.5·rho·C_D·S·V²
-+0.5645 : W = 0.5·rho·C_L·S·V²
++0.5645 : W ≤ 0.5·rho·C_L·S·V²
 +0.2714 : C_Di ≥ C_L²/(π·e·A)
 
 UAV.Mission.Return.AircraftPerf.PropulsionPerf

--- a/gpkit/examples/uav.py
+++ b/gpkit/examples/uav.py
@@ -352,12 +352,16 @@ class HeavyLandingCase(Model):
 
 
 class UAV(Model):
-    """Fixed-wing UAV: minimize total fuel for an out-and-back mission.
+    """Fixed-wing UAV minimizing fuel for a symmetric out-and-back mission.
 
-    Submodels are accessed via attributes (e.g. self.aircraft.wing,
-    self.mission.outbound_leg) rather than string-key indexing.  String-key
-    access via model["name"] remains available for programmatic traversal.
+    Submodels are accessed via attributes (aircraft.wing, mission.outbound_leg).
     """
+
+    references = [
+        'W. Hoburg, "Geometric Programming for Aircraft Design Optimization,"'
+        " PhD thesis, MIT/UC Berkeley, 2013."
+        " https://people.eecs.berkeley.edu/~pabbeel/papers/2013_Hoburg-phdthesis.pdf"
+    ]
 
     def setup(self):
         self.aircraft = Aircraft()

--- a/gpkit/examples/uav.py
+++ b/gpkit/examples/uav.py
@@ -291,6 +291,7 @@ class Mission(Model):
 
     R = Var("m", "mission leg range")
     R_min = Var("km", "minimum range requirement", value=5e3)
+    W_fuel = Var("N", "total fuel weight")
 
     def setup(self, aircraft):
         self.outbound_leg = Outbound(aircraft, self.R)
@@ -303,10 +304,13 @@ class Mission(Model):
             self.return_leg,
             self.sprint,
             self.R >= self.R_min,
+            # Sequential mission dynamics (Breguet correctness, sprint sizing):
             W_out >= aircraft.W_zfw + self.return_leg.W_fuel,
             W_ret >= aircraft.W_zfw,
-            aircraft.W_mto >= W_out + self.outbound_leg.W_fuel,
             self.sprint.perf.W == W_out,
+            # Budget-friendly takeoff weight chain:
+            self.W_fuel >= self.outbound_leg.W_fuel + self.return_leg.W_fuel,
+            aircraft.W_mto >= aircraft.W_zfw + self.W_fuel,
         ]
 
 

--- a/gpkit/examples/uav.py
+++ b/gpkit/examples/uav.py
@@ -330,8 +330,8 @@ class SprintCondition(Model):
         ]
 
 
-class LandingCondition(Model):
-    """Landing: stall speed constraint at MTOW and sea-level density."""
+class HeavyLandingCase(Model):
+    """Sizing case: stall speed constraint at MTOW and sea-level density."""
 
     V_stall = Var("m/s", "stall speed")
     V_stallmax = Var("m/s", "stall speed limit", value=38)
@@ -362,12 +362,12 @@ class UAV(Model):
     def setup(self):
         self.aircraft = Aircraft()
         self.mission = Mission(self.aircraft)
-        self.landing = LandingCondition(self.aircraft)
+        self.heavy_landing = HeavyLandingCase(self.aircraft)
         self.cost = self.mission.outbound_leg.W_fuel + self.mission.return_leg.W_fuel
         return [
             self.aircraft,
             self.mission,
-            self.landing,
+            self.heavy_landing,
         ]
 
 

--- a/gpkit/examples/uav.py
+++ b/gpkit/examples/uav.py
@@ -238,7 +238,7 @@ class AircraftPerf(Model):
             state,
             self.wing_aero,
             self.prop_perf,
-            self.W == 0.5 * rho * C_L * S * V**2,
+            self.W <= 0.5 * rho * C_L * S * V**2,
             self.T >= 0.5 * rho * self.C_D * S * V**2,
             self.C_Di >= C_L**2 / (pi * e * A),
             self.C_D >= aircraft.CDA0 / S + C_Dp + self.C_Di,


### PR DESCRIPTION
This makes various small tweaks to the model hierarchy in the UAV example, which will make weight budgets cleaner for this example. No changes to the output values, just their hierarchical relations