### PR TITLE
handle zero substitutions more reliably

### DIFF
--- a/gpkit/nomials/map.py
+++ b/gpkit/nomials/map.py
@@ -179,6 +179,8 @@ class NomialMap(HashVector):
                 raise ValueError("Monomial substitutions are not supported.")
             for o_exp, exp in exps:
                 subinplace(cp, exp, o_exp, vk, cval, squished)
+        if not cp:
+            cp[EMPTY_HV] = 0.0
         return cp
 
     def mmap(self, orig):
@@ -228,8 +230,6 @@ def subinplace(cp, exp, o_exp, vk, cval, squished):
                 del cp[exp]  # remove zeros created during substitution
         elif value:
             cp[exp] = value
-        if not cp:  # make sure it's never an empty hmap
-            cp[EMPTY_HV] = 0.0
     elif exp in squished:
         exp.hashvalue ^= hash((vk, x))  # remove (key, value) from hashvalue
         del exp[vk]

--- a/gpkit/nomials/math.py
+++ b/gpkit/nomials/math.py
@@ -465,6 +465,8 @@ class PosynomialInequality(ScalarSingleEquationConstraint):
     # pylint: disable=attribute-defined-outside-init
     def _simplify_posy_ineq(self, hmap, pmap=None, fixed=None):
         "Simplify a posy <= 1 by moving constants to the right side."
+        if not hmap:
+            return None  # all terms zeroed out → constraint is 0 ≤ 1 (tautological)
         if EMPTY_HV not in hmap:
             return hmap
         coeff = 1 - hmap[EMPTY_HV]

--- a/gpkit/solutions.py
+++ b/gpkit/solutions.py
@@ -109,9 +109,9 @@ class Solution:
             return self.constants.quantity(key)
         if hasattr(key, "sub"):
             subbed = key.sub(self.variables, require_positive=False)
-            # subbed should be a constant monomial
-            assert getattr(subbed, "exp", {}) == {}
-            c = getattr(subbed, "c", subbed)
+            # Use .cs rather than .c: a zero-valued sub produces a Signomial
+            # (0 ≤ 0 triggers any_nonpositive_cs), which lacks .c but has .cs.
+            (c,) = subbed.cs
             if isinstance(c, Quantity):
                 return c
             return Quantity(c, key.units or "dimensionless")

--- a/gpkit/tests/test_budgets.py
+++ b/gpkit/tests/test_budgets.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=attribute-defined-outside-init,too-many-lines
 
+import json
 import math
 import warnings
 
@@ -87,6 +88,25 @@ class SlackModel(Model):
         return [
             self.m_total >= self.m_wing,  # budget constraint (slack: 100 > 60)
             self.m_wing >= m_wing_min,  # wing: forces m_wing = 60 kg
+        ]
+
+
+class ZeroTermBudgetModel(Model):
+    """Budget where one term has a zero substitution (value=0).
+
+    Substituting 0 into a GP Monomial can produce a Signomial rather than a
+    numeric quantity, causing _make_term to silently return NaN and to_dict()
+    to emit values that strict JSON serializers reject.
+    """
+
+    def setup(self):  # pylint: disable=attribute-defined-outside-init
+        m_pay = Variable("m_pay", 0, "kg", "zero-valued term")
+        self.m_struct = Variable("m_struct", "kg", "structural mass")
+        self.m = Variable("m", "kg", "total mass")
+        self.cost = self.m
+        return [
+            self.m >= self.m_struct + m_pay,
+            self.m_struct >= Variable("m_struct_min", 10, "kg"),
         ]
 
 
@@ -295,6 +315,20 @@ class TestBudgetRendering:
         assert d["units"] == "kg"
         assert isinstance(d["children"], list)
         assert d["total"] == pytest.approx(b.total)
+
+    def test_to_dict_zero_term_json_safe(self):
+        """A zero-substituted budget term must not produce NaN in to_dict().
+
+        Substituting 0 into a GP Monomial via Solution.__getitem__ returns a
+        Signomial rather than a numeric quantity, making _make_term fall back
+        to NaN.  NaN is not valid JSON when serialized with allow_nan=False
+        (as used by Starlette and other strict HTTP frameworks).
+        """
+        model = ZeroTermBudgetModel()
+        sol, _ = solve(model)
+        d = build_budget(sol, model, model.m).to_dict()
+        # allow_nan=False mirrors strict serializers (e.g. Starlette JSONResponse)
+        json.dumps(d, allow_nan=False)
 
     def test_repr_is_text(self):
         model = Aircraft()


### PR DESCRIPTION
1. `nomials/map.py`: moved the "never return empty NomialMap" invariant from subinplace to NomialMap.sub()  (a postcondition of the public method, not a detail of individual term arithmetic)
2. `nomials/math.py`: `_simplify_posy_ineq` now handles empty hmaps explicitly — an empty hmap means all terms
  zeroed out, which is a tautology (0 ≤ 1)
3. `solutions.py`: `Solution.__getitem__` uses .cs instead of .c — .cs is defined on all nomials including the zero-valued Signomial that comes back from a zero substitution; .c is Monomial-only