### PR TITLE
add MarginObjective capability

### DIFF
--- a/docs/source/examples/growth_allowance_output.txt
+++ b/docs/source/examples/growth_allowance_output.txt
@@ -7,14 +7,14 @@ Budget  —  GrowthAllowance.m
 
 mass margin: 4.36 kg  (plus=40 kg, minus=35.64 kg)
   ∂(mass margin)/∂c [by |GP sensitivity|]:
-    rho                   -0.0066 kg/(kg/m³)
-    t                     -3564 kg/m
-    A                     -17.82 kg/m²
-    rho                   -0.0066 kg/(kg/m³)
-    t                     -3564 kg/m
-    A                     -17.82 kg/m²
+    Spar.rho              -0.0066 kg/(kg/m³)
+    Spar.t                -3564 kg/m
+    Spar.A                -17.82 kg/m²
+    Spar1.rho             -0.0066 kg/(kg/m³)
+    Spar1.t               -3564 kg/m
+    Spar1.A               -17.82 kg/m²
     theta                 -9.18 kg
-    f_growth_m            -32.4 kg
-    f_growth_m            -14.85 kg
-    f_growth_m            -14.85 kg
+    GrowthAllowance.f_growth_m  -32.4 kg
+    Spar.f_growth_m       -14.85 kg
+    Spar1.f_growth_m      -14.85 kg
     m_budget              +1 kg/kg

--- a/docs/source/examples/growth_allowance_output.txt
+++ b/docs/source/examples/growth_allowance_output.txt
@@ -7,12 +7,12 @@ Budget  —  GrowthAllowance.m
 
 mass margin: 4.36 kg  (plus=40 kg, minus=35.64 kg)
   ∂(mass margin)/∂c [by |GP sensitivity|]:
+    Spar.A                -17.82 kg/m²
     Spar.rho              -0.0066 kg/(kg/m³)
     Spar.t                -3564 kg/m
-    Spar.A                -17.82 kg/m²
+    Spar1.A               -17.82 kg/m²
     Spar1.rho             -0.0066 kg/(kg/m³)
     Spar1.t               -3564 kg/m
-    Spar1.A               -17.82 kg/m²
     theta                 -9.18 kg
     GrowthAllowance.f_growth_m  -32.4 kg
     Spar.f_growth_m       -14.85 kg

--- a/docs/source/examples/growth_allowance_output.txt
+++ b/docs/source/examples/growth_allowance_output.txt
@@ -4,3 +4,17 @@ Budget  —  GrowthAllowance.m
   GrowthAllowance.m       27    8.64  35.64  [kg]  100.0%
     Spar.m              13.5     2.7   16.2  [kg]   45.5%
     Spar1.m             13.5     2.7   16.2  [kg]   45.5%
+
+mass margin: 4.36 kg  (A=40 kg, B=35.64 kg)
+  ∂(mass margin)/∂log(c) [most negative first]:
+    rho                   -17.82 kg  (-408.7%)
+    t                     -17.82 kg  (-408.7%)
+    A                     -17.82 kg  (-408.7%)
+    rho                   -17.82 kg  (-408.7%)
+    t                     -17.82 kg  (-408.7%)
+    A                     -17.82 kg  (-408.7%)
+    theta                 -9.18 kg  (-210.6%)
+    f_growth_m            -3.24 kg  (-74.3%)
+    f_growth_m            -2.97 kg  (-68.1%)
+    f_growth_m            -2.97 kg  (-68.1%)
+    m_budget              +40 kg  (+917.4%)

--- a/docs/source/examples/growth_allowance_output.txt
+++ b/docs/source/examples/growth_allowance_output.txt
@@ -6,15 +6,15 @@ Budget  —  GrowthAllowance.m
     Spar1.m             13.5     2.7   16.2  [kg]   45.5%
 
 mass margin: 4.36 kg  (plus=40 kg, minus=35.64 kg)
-  ∂(mass margin)/∂c [most negative first]:
+  ∂(mass margin)/∂c [by |GP sensitivity|]:
+    rho                   -0.0066 kg/(kg/m³)
     t                     -3564 kg/m
+    A                     -17.82 kg/m²
+    rho                   -0.0066 kg/(kg/m³)
     t                     -3564 kg/m
-    f_growth_m            -32.4 kg
     A                     -17.82 kg/m²
-    A                     -17.82 kg/m²
-    f_growth_m            -14.85 kg
-    f_growth_m            -14.85 kg
     theta                 -9.18 kg
-    rho                   -0.0066 kg/(kg/m³)
-    rho                   -0.0066 kg/(kg/m³)
+    f_growth_m            -32.4 kg
+    f_growth_m            -14.85 kg
+    f_growth_m            -14.85 kg
     m_budget              +1 kg/kg

--- a/docs/source/examples/growth_allowance_output.txt
+++ b/docs/source/examples/growth_allowance_output.txt
@@ -5,16 +5,16 @@ Budget  —  GrowthAllowance.m
     Spar.m              13.5     2.7   16.2  [kg]   45.5%
     Spar1.m             13.5     2.7   16.2  [kg]   45.5%
 
-mass margin: 4.36 kg  (A=40 kg, B=35.64 kg)
-  ∂(mass margin)/∂log(c) [most negative first]:
-    rho                   -17.82 kg  (-408.7%)
-    t                     -17.82 kg  (-408.7%)
-    A                     -17.82 kg  (-408.7%)
-    rho                   -17.82 kg  (-408.7%)
-    t                     -17.82 kg  (-408.7%)
-    A                     -17.82 kg  (-408.7%)
-    theta                 -9.18 kg  (-210.6%)
-    f_growth_m            -3.24 kg  (-74.3%)
-    f_growth_m            -2.97 kg  (-68.1%)
-    f_growth_m            -2.97 kg  (-68.1%)
-    m_budget              +40 kg  (+917.4%)
+mass margin: 4.36 kg  (plus=40 kg, minus=35.64 kg)
+  ∂(mass margin)/∂c [most negative first]:
+    t                     -3564 kg/m
+    t                     -3564 kg/m
+    f_growth_m            -32.4 kg
+    A                     -17.82 kg/m²
+    A                     -17.82 kg/m²
+    f_growth_m            -14.85 kg
+    f_growth_m            -14.85 kg
+    theta                 -9.18 kg
+    rho                   -0.0066 kg/(kg/m³)
+    rho                   -0.0066 kg/(kg/m³)
+    m_budget              +1 kg/kg

--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -8,6 +8,7 @@ from .ast_nodes import PiNode as _PiNode
 from .constraints.costed import Objective
 from .constraints.set import ConstraintSet
 from .constraints.sigeq import SignomialEquality
+from .margin_objective import MarginObjective
 from .model import Model
 from .nomials import (
     ArrayVariable,

--- a/gpkit/examples/growth_allowance.py
+++ b/gpkit/examples/growth_allowance.py
@@ -1,9 +1,12 @@
-"""Mass budget with growth allowances at two levels.
+"""Mass budget with growth allowances and mass margin tracking.
 
 Each Spar declares a 20% allowance on top of its physics-based estimate; the
 Wing applies an additional 10% subsystem-level allowance on top of the spars'
 totals. The rendered budget table shows CBE + GA = Total at every row, and
 the GA column accumulates recursively up the tree.
+
+A MarginObjective tracks how much headroom remains against a fixed mass budget,
+and reports how each constant parameter drives or erodes that margin.
 
 The shared theta variable (``from gpkit.nomials.growth import theta``)
 defaults to 1.0 (auto-substituted), so models that don't care about it
@@ -13,7 +16,7 @@ simultaneously; freeing theta and adding it to the cost lets the optimizer
 choose how much margin to carry.
 """
 
-from gpkit import Model, Variable
+from gpkit import MarginObjective, Model, Variable
 from gpkit.budgets import build_budget
 
 
@@ -35,7 +38,8 @@ class GrowthAllowance(Model):
     """Growth allowances demo: wing mass budgeted across two spars.
 
     Spars carry 20% component-level allowances; the wing applies an additional
-    10% subsystem-level allowance on top of the spars' totals.
+    10% subsystem-level allowance on top of the spars' totals.  A MarginObjective
+    tracks remaining headroom against a fixed mass budget.
     """
 
     spar1: Spar
@@ -46,9 +50,16 @@ class GrowthAllowance(Model):
         self.spar1 = Spar()
         self.spar2 = Spar()
         self.m = Variable("m", "kg", "wing mass", growth=0.10)
+        m_budget = Variable("m_budget", 40.0, "kg", "mass budget")
         self.cost = self.m
+        self.margin_objective = MarginObjective(
+            "mass margin",
+            plus_var=m_budget,
+            minus_var=self.m,
+        )
         return [
             self.m.grown_from(self.spar1.m + self.spar2.m),
+            self.m <= m_budget,
             self.spar1,
             self.spar2,
         ]
@@ -58,3 +69,4 @@ if __name__ == "__main__":
     model = GrowthAllowance()
     sol = model.solve(verbosity=0)
     print(build_budget(sol, model, model.m).text())
+    print(sol.derived.table())

--- a/gpkit/examples/growth_allowance.py
+++ b/gpkit/examples/growth_allowance.py
@@ -69,4 +69,4 @@ if __name__ == "__main__":
     model = GrowthAllowance()
     sol = model.solve(verbosity=0)
     print(build_budget(sol, model, model.m).text())
-    print(sol.derived.table())
+    print(sol.derived.table(sol.sens.variables))

--- a/gpkit/margin_objective.py
+++ b/gpkit/margin_objective.py
@@ -1,0 +1,16 @@
+"MarginObjective: user-facing signed-difference objective with sensitivity tracking"
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MarginObjective:
+    """Specifies a maximize(plus_var − minus_var) user-facing objective.
+
+    Attach as ``self.margin_objective = MarginObjective(...)`` in ``Model.setup()``.
+    After solving, ``Solution.derived`` holds the value and per-constant sensitivities.
+    """
+
+    name: str
+    plus_var: object  # Variable or VarKey (A)
+    minus_var: object  # Variable or VarKey (B)

--- a/gpkit/margin_objective.py
+++ b/gpkit/margin_objective.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+from .varkey import VarKey
+
 
 @dataclass
 class MarginObjective:
@@ -9,8 +11,15 @@ class MarginObjective:
 
     Attach as ``self.margin_objective = MarginObjective(...)`` in ``Model.setup()``.
     After solving, ``Solution.derived`` holds the value and per-constant sensitivities.
+    plus_var and minus_var may be Variable or VarKey; they are normalized to VarKey.
     """
 
     name: str
-    plus_var: object  # Variable or VarKey (A)
-    minus_var: object  # Variable or VarKey (B)
+    plus_var: VarKey
+    minus_var: VarKey
+
+    def __post_init__(self):
+        if hasattr(self.plus_var, "key"):
+            self.plus_var = self.plus_var.key
+        if hasattr(self.minus_var, "key"):
+            self.minus_var = self.minus_var.key

--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -310,12 +310,10 @@ class Model(CostedConstraintSet):  # pylint: disable=too-many-instance-attribute
 
         if self.margin_objective is not None:
             mo = self.margin_objective
-            plus_key = getattr(mo.plus_var, "key", mo.plus_var)
-            minus_key = getattr(mo.minus_var, "key", mo.minus_var)
             ir["margin_objective"] = {
                 "name": mo.name,
-                "plus_var": plus_key.ref,
-                "minus_var": minus_key.ref,
+                "plus_var": mo.plus_var.ref,
+                "minus_var": mo.minus_var.ref,
             }
 
         return ir

--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -306,6 +306,16 @@ class Model(CostedConstraintSet):  # pylint: disable=too-many-instance-attribute
         # Phase 5: structural metadata for nested/composable models
         ir["model_tree"] = build_model_tree(self)
 
+        if getattr(self, "margin_objective", None) is not None:
+            mo = self.margin_objective
+            A_key = getattr(mo.plus_var, "key", mo.plus_var)
+            B_key = getattr(mo.minus_var, "key", mo.minus_var)
+            ir["margin_objective"] = {
+                "name": mo.name,
+                "plus_var": A_key.ref,
+                "minus_var": B_key.ref,
+            }
+
         return ir
 
     @classmethod

--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -59,6 +59,7 @@ class Model(CostedConstraintSet):  # pylint: disable=too-many-instance-attribute
     program = None
     solution = None
     computed = None  # dict of {VarKey: fn(solution) -> value} for post-solve
+    margin_objective = None
     _is_model_subclass = False  # True for any subclass; False for bare Model
 
     def __init_subclass__(cls, **kwargs):
@@ -306,14 +307,14 @@ class Model(CostedConstraintSet):  # pylint: disable=too-many-instance-attribute
         # Phase 5: structural metadata for nested/composable models
         ir["model_tree"] = build_model_tree(self)
 
-        if getattr(self, "margin_objective", None) is not None:
+        if self.margin_objective is not None:
             mo = self.margin_objective
-            A_key = getattr(mo.plus_var, "key", mo.plus_var)
-            B_key = getattr(mo.minus_var, "key", mo.minus_var)
+            plus_key = getattr(mo.plus_var, "key", mo.plus_var)
+            minus_key = getattr(mo.minus_var, "key", mo.minus_var)
             ir["margin_objective"] = {
                 "name": mo.name,
-                "plus_var": A_key.ref,
-                "minus_var": B_key.ref,
+                "plus_var": plus_key.ref,
+                "minus_var": minus_key.ref,
             }
 
         return ir

--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -14,6 +14,7 @@ from .exceptions import (
     InvalidGPConstraint,
     VariableNotFound,
 )
+from .margin_objective import MarginObjective
 from .nomials import Monomial, Variable
 from .nomials.map import DIMLESS_QUANTITY
 from .nomials.math import constraint_from_ir, nomial_from_ir
@@ -363,7 +364,19 @@ class Model(CostedConstraintSet):  # pylint: disable=too-many-instance-attribute
                 if ref in var_registry:
                     subs[var_registry[ref]] = val
 
-        return cls(cost, constraints, substitutions=subs)
+        model = cls(cost, constraints, substitutions=subs)
+
+        if "margin_objective" in ir_doc:
+            mo_ir = ir_doc["margin_objective"]
+            plus_vk = var_registry[mo_ir["plus_var"]]
+            minus_vk = var_registry[mo_ir["minus_var"]]
+            model.margin_objective = MarginObjective(
+                name=mo_ir["name"],
+                plus_var=plus_vk,
+                minus_var=minus_vk,
+            )
+
+        return model
 
     def save(self, path):
         """Write this Model's IR to a JSON file."""

--- a/gpkit/programs/gp.py
+++ b/gpkit/programs/gp.py
@@ -500,55 +500,28 @@ class GeometricProgram:
 
         return cost_senss, gpv_ss, absv_ss, m_senss, constraint_senss
 
-    def _compute_variable_sensitivities(self, nu, primal_weights):
-        """Compute ∂(Σ w_i x_i*)/∂log(c_m) via one linear solve.
+    def _compute_free_var_adjoints(self, nu, free_varkeys):
+        """Compute per-variable adjoint qnu vectors via one batched linear solve.
 
-        The quantity of interest is a linear combination of primal values,
-        e.g. plus_val - minus_val for a margin.  Because the GP KKT system
-        is in log-space, the weight for variable x_i is w_i = coeff * x_i*
-        (the chain rule factor x_i* converts ∂log(x_i) to ∂x_i).
+        For each vk in free_varkeys, solves ac^T v_j = e_j (unit vector at
+        varcols[vk]) so that ∂x_j*/∂log(c) can be accumulated from qnu_j.
 
-        Parameters
-        ----------
-        nu : array
-            Full dual variable vector (length = total monomials, including cost).
-        primal_weights : dict
-            {VarKey: float} — per-variable weights w_i = sign * x_i* for each
-            free variable that appears in the quantity of interest.  Only free
-            variables (those in self.varcols) should be included; constants are
-            handled as direct corrections by the caller.
+        ac (n_tight × n_vars) has one row per active constraint:
+        ac[i,:] = nu_i @ A_i / lambda_i.  Slack constraints are skipped.
 
-        Returns
-        -------
-        (v_prime, qnu, constraint_v) : tuple of np.ndarray
-            v_prime      — solution to ac^T v' = w, one entry per tight constraint
-            qnu          — sensitivity weight per constraint monomial:
-                           qnu[k] = (v'[i] / lambda_i) * nu_constr[k]
-            constraint_v — v'[i] broadcast to constraint index space
-
-        Notes
-        -----
-        ac (n_tight × n_vars) is the matrix of nu-weighted average exponents,
-        one row per tight constraint: ac[i,:] = nu_i @ A_i / lambda_i.
-        Slack constraints (lambda_i ≈ 0) are skipped; they contribute nothing.
+        Returns {VarKey: (qnu_array, constraint_v_array)} for each vk in
+        free_varkeys that is present in self.varcols.
         """
         obj_end = self.data.m_idxs[0].stop
-        exponent_block = self.data.A.tocsr()[
-            obj_end:, :
-        ]  # sparse (n_constr_mono, n_vars)
+        exponent_block = self.data.A.tocsr()[obj_end:, :]
         nu_constr = np.asarray(nu[obj_end:], dtype=float)
         n_vars = len(self.vars)
+        n_constr_mono = len(nu_constr)
+        n_constr = len(self.data.m_idxs) - 1
 
-        # Build ac: one dense row per tight constraint.
-        # ac[i,:] = nu_i @ A_i / lambda_i  (nu-weighted average of exponents).
-        # Relative threshold: skip constraints whose dual weight is negligible compared
-        # to the overall dual magnitude (cvxopt solver tolerance ≈ 1e-5).
         nu_scale = float(nu_constr.sum()) + 1.0
-
         ac_rows = []
-        tight_slices = (
-            []
-        )  # (q_start, q_end, lambda_i, constr_i) for each tight constraint
+        tight_slices = []
         for constr_i, m_idx in enumerate(self.data.m_idxs[1:]):
             q_start = m_idx.start - obj_end
             q_end = m_idx.stop - obj_end
@@ -556,42 +529,52 @@ class GeometricProgram:
             lambda_i = float(nu_i.sum())
             if lambda_i < 1e-5 * nu_scale:
                 continue
-            # exponent_block[q_start:q_end, :].T @ nu_i  →  dense (n_vars,)
             ac_row = np.asarray(exponent_block[q_start:q_end, :].T.dot(nu_i)).ravel()
             ac_rows.append(ac_row / lambda_i)
             tight_slices.append((q_start, q_end, lambda_i, constr_i))
 
-        n_constr = len(self.data.m_idxs) - 1
-        qnu = np.zeros(len(nu_constr))
-        constraint_v = np.zeros(n_constr)
-        if not ac_rows:
-            return np.zeros(0), qnu, constraint_v
+        valid_vks = [vk for vk in free_varkeys if vk in self.varcols]
+        result = {vk: (np.zeros(n_constr_mono), np.zeros(n_constr)) for vk in valid_vks}
 
-        ac = np.vstack(ac_rows)  # (n_tight × n_vars) dense
+        if not ac_rows or not valid_vks:
+            return result
 
-        w = np.zeros(n_vars)
-        for vk, coeff in primal_weights.items():
-            if vk in self.varcols:
-                w[self.varcols[vk]] = coeff
+        ac = np.vstack(ac_rows)  # (n_tight × n_vars)
 
-        # Solve ac^T v' = w: (n_vars equations, n_tight unknowns)
-        v_prime, _, _, _ = np.linalg.lstsq(ac.T, w, rcond=None)
+        # Each column of W is a unit vector selecting one free variable.
+        W = np.zeros((n_vars, len(valid_vks)))
+        for j, vk in enumerate(valid_vks):
+            W[self.varcols[vk], j] = 1.0
 
-        # For each tight constraint i, broadcast v'_i / lambda_i across its
-        # constituent monomials, weighted by nu_constr.  Also record v'_i by
-        # constraint index so callers can apply const_mmap corrections.
-        for j, (q_start, q_end, lambda_i, constr_i) in enumerate(tight_slices):
-            qnu[q_start:q_end] = (v_prime[j] / lambda_i) * nu_constr[q_start:q_end]
-            constraint_v[constr_i] = v_prime[j]
+        V, _, _, _ = np.linalg.lstsq(ac.T, W, rcond=None)
 
-        return v_prime, qnu, constraint_v
+        for j, vk in enumerate(valid_vks):
+            qnu = np.zeros(n_constr_mono)
+            cv = np.zeros(n_constr)
+            for i, (q_start, q_end, lambda_i, constr_i) in enumerate(tight_slices):
+                qnu[q_start:q_end] = (V[i, j] / lambda_i) * nu_constr[q_start:q_end]
+                cv[constr_i] = V[i, j]
+            result[vk] = (qnu, cv)
 
-    def _accumulate_posy_const_sens(self, const_senss, hmap_qnu, c):
-        """Accumulate ∂(A−B)/∂log(c_m) contributions from one PosynomialInequality.
+        return result
 
-        The inner loops (pmap entries × exponent dict entries) are O(1) and
-        O(2-5) per monomial respectively in typical engineering models.
+    def _propagate_linked_derivs(self, sens_dict):
+        """Apply linked-constant chain rule to sens_dict in-place.
+
+        Pops each intermediate VarKey that has linked derivatives and
+        accumulates its sensitivity into the base constants.
         """
+        for v in list(v for v in sens_dict if self.linked_derivs.get(v)):
+            dsens_dlogv = sens_dict.pop(v)
+            val = np.array(self.substitutions[v])
+            for c, dv_dc in self.linked_derivs[v].items():
+                with pywarnings.catch_warnings():
+                    pywarnings.simplefilter("ignore")
+                    dlogv_dlogc = dv_dc * self.substitutions[c] / val
+                    sens_dict[c] = sens_dict.get(c, 0) + dsens_dlogv * dlogv_dlogc
+
+    def _accumulate_posy_const_sens(self, const_senss, hmap_qnu, c, presub_exps):
+        """Accumulate ∂(A−B)/∂log(c_m) contributions from one PosynomialInequality."""
         if not hasattr(c, "pmap"):
             raise RuntimeError(
                 f"Constraint {c!r} is missing pmap.  "
@@ -599,29 +582,26 @@ class GeometricProgram:
                 "_calculate_sensitivities (which deletes pmap).  "
                 "See issue #200."
             )
-        presub_exps = list(c.unsubbed[0].hmap)
         for k, qnu_j in enumerate(hmap_qnu):
             for presub_idx, fraction in c.pmap[k].items():
                 for vk, exp in presub_exps[presub_idx].items():
-                    if vk not in self.varcols:  # constant VarKey
+                    if vk not in self.varcols:
                         const_senss[vk] -= qnu_j * fraction * exp
 
-    def _apply_const_mmap_correction(self, const_senss, c, v_i):
+    def _apply_const_mmap_correction(self, const_senss, c, v_i, presub_exps):
         """Apply const_mmap correction to const_senss for one constraint.
 
-        Constants absorbed into the constraint RHS shift the effective tight
-        condition when perturbed.  Mirrors the sens_from_dual correction but
-        scaled by v'_i (the per-constraint dual weight from the linear solve).
+        Constants absorbed into the RHS shift the effective tight condition
+        when perturbed.  Mirrors the sens_from_dual correction scaled by v_i.
         """
         scale = (1 - c.const_coeff) / c.const_coeff
-        presub_exps = list(c.unsubbed[0].hmap)
         for const_presub_idx, pct in c.const_mmap.items():
             for vk, exp in presub_exps[const_presub_idx].items():
                 if vk not in self.varcols:
                     const_senss[vk] -= v_i * pct * scale * exp
 
     def _compute_margin_sensitivity(self, nu, varvals, margin_obj):
-        """Compute ∂(A−B)/∂log(c) for every constant c via one linear solve.
+        """Compute ∂(A−B)/∂c for every constant c via one batched adjoint solve.
 
         Must be called BEFORE _calculate_sensitivities() because pmap is deleted
         there.  See GitHub issue #200 for the pmap mutation discussion.
@@ -641,25 +621,35 @@ class GeometricProgram:
         """
         plus_vk = getattr(margin_obj.plus_var, "key", margin_obj.plus_var)
         minus_vk = getattr(margin_obj.minus_var, "key", margin_obj.minus_var)
-        plus_val = float(varvals.get(plus_vk, 0))
-        minus_val = float(varvals.get(minus_vk, 0))
+        assert (
+            not plus_vk.shape
+        ), f"MarginObjective plus_var must be scalar, got shape {plus_vk.shape!r}"
+        assert (
+            not minus_vk.shape
+        ), f"MarginObjective minus_var must be scalar, got shape {minus_vk.shape!r}"
 
-        primal_weights = {}
-        if plus_vk in self.varcols:
-            primal_weights[plus_vk] = plus_val
-        if minus_vk in self.varcols:
-            primal_weights[minus_vk] = -minus_val
+        plus_val = float(varvals[plus_vk])
+        minus_val = float(varvals[minus_vk])
 
-        _, qnu, constraint_v = self._compute_variable_sensitivities(nu, primal_weights)
+        # Compute per-variable adjoints for the free variables among plus/minus.
+        free_margin_vks = [vk for vk in [plus_vk, minus_vk] if vk in self.varcols]
+        adjoints = self._compute_free_var_adjoints(nu, free_margin_vks)
 
-        # Accumulate ∂(A−B)/∂log(c_m) = −Σ_j qnu_j * e_{jm} for each constant c_m.
-        # Slack constraints self-eliminate: complementarity gives nu_k = 0 for
-        # inactive constraints, so their qnu is zero and they contribute nothing.
+        # Combine linearly: margin = plus - minus → weights are +plus_val, -minus_val.
         obj_end = self.data.m_idxs[0].stop
+        nu_constr = np.asarray(nu[obj_end:], dtype=float)
+        n_constr = len(self.data.m_idxs) - 1
+        qnu = np.zeros(len(nu_constr))
+        constraint_v = np.zeros(n_constr)
+        weights = {plus_vk: plus_val, minus_vk: -minus_val}
+        for vk, (qnu_vk, cv_vk) in adjoints.items():
+            w = weights[vk]
+            qnu += w * qnu_vk
+            constraint_v += w * cv_vk
+
+        # Accumulate ∂(A−B)/∂log(c_m) for each constant c_m.
         const_senss = defaultdict(float)
-        meq_unsubbed_idx = defaultdict(
-            int
-        )  # which unsubbed to use per MonomialEquality
+        meq_unsubbed_idx = defaultdict(int)
 
         for i, hmap in enumerate(self.hmaps[1:]):
             c = hmap
@@ -672,7 +662,6 @@ class GeometricProgram:
 
             if getattr(hmap, "from_meq", False):
                 # MonomialEquality emits two hmaps sharing one parent object.
-                # Track which unsubbed index belongs to each (first=0, second=1).
                 parent_id = id(c)
                 unsubbed_idx = meq_unsubbed_idx[parent_id]
                 meq_unsubbed_idx[parent_id] += 1
@@ -682,33 +671,27 @@ class GeometricProgram:
                     if vk not in self.varcols:
                         const_senss[vk] -= qnu_j * exp
             else:
-                self._accumulate_posy_const_sens(const_senss, hmap_qnu, c)
+                presub_exps = list(c.unsubbed[0].hmap)
+                self._accumulate_posy_const_sens(const_senss, hmap_qnu, c, presub_exps)
                 if hasattr(c, "const_mmap"):
-                    self._apply_const_mmap_correction(const_senss, c, constraint_v[i])
+                    self._apply_const_mmap_correction(
+                        const_senss, c, constraint_v[i], presub_exps
+                    )
 
-        # Direct contributions when plus_var or minus_var are constants
+        # Direct contributions when plus_var or minus_var are constants.
         if plus_vk not in self.varcols:
             const_senss[plus_vk] += plus_val
         if minus_vk not in self.varcols:
             const_senss[minus_vk] -= minus_val
 
-        # Chain rule for linked constants (same pattern as _calculate_sensitivities).
-        # pywarnings suppresses RuntimeWarning from 0-division when val == 0.
-        for v in list(vk for vk in const_senss if self.linked_derivs.get(vk)):
-            d_margin_d_logv = const_senss.pop(v)
-            val = np.array(self.substitutions[v])
-            for linked_c, dv_dc in self.linked_derivs[v].items():
-                with pywarnings.catch_warnings():
-                    pywarnings.simplefilter("ignore")
-                    dlogv_dlogc = dv_dc * self.substitutions[linked_c] / val
-                    const_senss[linked_c] += d_margin_d_logv * dlogv_dlogc
+        self._propagate_linked_derivs(const_senss)
 
         # Convert ∂(margin)/∂log(c) → ∂(margin)/∂c by dividing by c*.
-        # This gives physically dimensioned sensitivities in [margin_units/c_units].
         with pywarnings.catch_warnings():
             pywarnings.simplefilter("ignore")
             for vk in list(const_senss):
-                c_val = float(self.substitutions.get(vk, 0))
+                c_val = float(self.substitutions[vk])
+                # Zero-valued constants have undefined log-space sensitivity; skip.
                 if c_val:
                     const_senss[vk] /= c_val
 

--- a/gpkit/programs/gp.py
+++ b/gpkit/programs/gp.py
@@ -501,43 +501,51 @@ class GeometricProgram:
         return cost_senss, gpv_ss, absv_ss, m_senss, constraint_senss
 
     def _compute_variable_sensitivities(self, nu, primal_weights):
-        """Compute ∂(Σ w_i x_i)/∂log(c_m) via one linear solve.
+        """Compute ∂(Σ w_i x_i*)/∂log(c_m) via one linear solve.
+
+        The quantity of interest is a linear combination of primal values,
+        e.g. plus_val - minus_val for a margin.  Because the GP KKT system
+        is in log-space, the weight for variable x_i is w_i = coeff * x_i*
+        (the chain rule factor x_i* converts ∂log(x_i) to ∂x_i).
 
         Parameters
         ----------
         nu : array
             Full dual variable vector (length = total monomials, including cost).
         primal_weights : dict
-            {VarKey: float} — coefficient of each free variable in the quantity
-            of interest.  E.g. {A_key: A_val, B_key: -B_val} for margin A − B.
+            {VarKey: float} — per-variable weights w_i = sign * x_i* for each
+            free variable that appears in the quantity of interest.  Only free
+            variables (those in self.varcols) should be included; constants are
+            handled as direct corrections by the caller.
 
         Returns
         -------
-        (v_prime, qnu) : (np.ndarray, np.ndarray)
-            v_prime — solution to A_c^T v' = w, one entry per tight constraint
-            qnu     — sensitivity weight per constraint monomial:
-                      qnu[k] = (v'[i] / lambda_i) * nu_constr[k],
-                      where i is the tight-constraint index for monomial k and
-                      lambda_i = sum(nu_constr[monomials of constraint i]).
+        (v_prime, qnu, constraint_v) : tuple of np.ndarray
+            v_prime      — solution to ac^T v' = w, one entry per tight constraint
+            qnu          — sensitivity weight per constraint monomial:
+                           qnu[k] = (v'[i] / lambda_i) * nu_constr[k]
+            constraint_v — v'[i] broadcast to constraint index space
 
         Notes
         -----
-        A_c (n_tight × n_vars) is the matrix of nu-weighted average exponents,
-        one row per tight constraint: A_c[i,:] = nu_i @ A_i / lambda_i.
+        ac (n_tight × n_vars) is the matrix of nu-weighted average exponents,
+        one row per tight constraint: ac[i,:] = nu_i @ A_i / lambda_i.
         Slack constraints (lambda_i ≈ 0) are skipped; they contribute nothing.
         """
         obj_end = self.data.m_idxs[0].stop
-        A_constr = self.data.A.tocsr()[obj_end:, :]  # sparse (n_constr_mono, n_vars)
+        exponent_block = self.data.A.tocsr()[
+            obj_end:, :
+        ]  # sparse (n_constr_mono, n_vars)
         nu_constr = np.asarray(nu[obj_end:], dtype=float)
         n_vars = len(self.vars)
 
-        # Build A_c: one dense row per tight constraint.
-        # A_c[i,:] = nu_i @ A_i / lambda_i  (nu-weighted average of exponents).
+        # Build ac: one dense row per tight constraint.
+        # ac[i,:] = nu_i @ A_i / lambda_i  (nu-weighted average of exponents).
         # Relative threshold: skip constraints whose dual weight is negligible compared
         # to the overall dual magnitude (cvxopt solver tolerance ≈ 1e-5).
         nu_scale = float(nu_constr.sum()) + 1.0
 
-        a_c_rows = []
+        ac_rows = []
         tight_slices = (
             []
         )  # (q_start, q_end, lambda_i, constr_i) for each tight constraint
@@ -548,26 +556,26 @@ class GeometricProgram:
             lambda_i = float(nu_i.sum())
             if lambda_i < 1e-5 * nu_scale:
                 continue
-            # A_constr[q_start:q_end, :].T @ nu_i  →  dense (n_vars,)
-            a_c_row = np.asarray(A_constr[q_start:q_end, :].T.dot(nu_i)).ravel()
-            a_c_rows.append(a_c_row / lambda_i)
+            # exponent_block[q_start:q_end, :].T @ nu_i  →  dense (n_vars,)
+            ac_row = np.asarray(exponent_block[q_start:q_end, :].T.dot(nu_i)).ravel()
+            ac_rows.append(ac_row / lambda_i)
             tight_slices.append((q_start, q_end, lambda_i, constr_i))
 
         n_constr = len(self.data.m_idxs) - 1
         qnu = np.zeros(len(nu_constr))
         constraint_v = np.zeros(n_constr)
-        if not a_c_rows:
+        if not ac_rows:
             return np.zeros(0), qnu, constraint_v
 
-        A_c = np.vstack(a_c_rows)  # (n_tight × n_vars) dense
+        ac = np.vstack(ac_rows)  # (n_tight × n_vars) dense
 
         w = np.zeros(n_vars)
         for vk, coeff in primal_weights.items():
             if vk in self.varcols:
                 w[self.varcols[vk]] = coeff
 
-        # Solve A_c^T v' = w: (n_vars equations, n_tight unknowns)
-        v_prime, _, _, _ = np.linalg.lstsq(A_c.T, w, rcond=None)
+        # Solve ac^T v' = w: (n_vars equations, n_tight unknowns)
+        v_prime, _, _, _ = np.linalg.lstsq(ac.T, w, rcond=None)
 
         # For each tight constraint i, broadcast v'_i / lambda_i across its
         # constituent monomials, weighted by nu_constr.  Also record v'_i by
@@ -598,6 +606,20 @@ class GeometricProgram:
                     if vk not in self.varcols:  # constant VarKey
                         const_senss[vk] -= qnu_j * fraction * exp
 
+    def _apply_const_mmap_correction(self, const_senss, c, v_i):
+        """Apply const_mmap correction to const_senss for one constraint.
+
+        Constants absorbed into the constraint RHS shift the effective tight
+        condition when perturbed.  Mirrors the sens_from_dual correction but
+        scaled by v'_i (the per-constraint dual weight from the linear solve).
+        """
+        scale = (1 - c.const_coeff) / c.const_coeff
+        presub_exps = list(c.unsubbed[0].hmap)
+        for const_presub_idx, pct in c.const_mmap.items():
+            for vk, exp in presub_exps[const_presub_idx].items():
+                if vk not in self.varcols:
+                    const_senss[vk] -= v_i * pct * scale * exp
+
     def _compute_margin_sensitivity(self, nu, varvals, margin_obj):
         """Compute ∂(A−B)/∂log(c) for every constant c via one linear solve.
 
@@ -611,22 +633,22 @@ class GeometricProgram:
         varvals : VarMap
             Combined free-variable primal values and substituted constants.
         margin_obj : MarginObjective
-            Specifies plus_var (A) and minus_var (B).
+            Specifies plus_var and minus_var; margin = plus_val - minus_val.
 
         Returns
         -------
         MarginSolution
         """
-        A_vk = getattr(margin_obj.plus_var, "key", margin_obj.plus_var)
-        B_vk = getattr(margin_obj.minus_var, "key", margin_obj.minus_var)
-        A_val = float(varvals.get(A_vk, 0))
-        B_val = float(varvals.get(B_vk, 0))
+        plus_vk = getattr(margin_obj.plus_var, "key", margin_obj.plus_var)
+        minus_vk = getattr(margin_obj.minus_var, "key", margin_obj.minus_var)
+        plus_val = float(varvals.get(plus_vk, 0))
+        minus_val = float(varvals.get(minus_vk, 0))
 
         primal_weights = {}
-        if A_vk in self.varcols:
-            primal_weights[A_vk] = A_val
-        if B_vk in self.varcols:
-            primal_weights[B_vk] = -B_val
+        if plus_vk in self.varcols:
+            primal_weights[plus_vk] = plus_val
+        if minus_vk in self.varcols:
+            primal_weights[minus_vk] = -minus_val
 
         _, qnu, constraint_v = self._compute_variable_sensitivities(nu, primal_weights)
 
@@ -661,24 +683,14 @@ class GeometricProgram:
                         const_senss[vk] -= qnu_j * exp
             else:
                 self._accumulate_posy_const_sens(const_senss, hmap_qnu, c)
-                # const_mmap: constants absorbed into the constraint RHS shift the
-                # effective tight-condition when they're perturbed.  Apply the same
-                # correction that sens_from_dual uses, but scaled by v'_i instead
-                # of nu[i] (mirrors the pmap → qnu2 transform for the free-var terms).
                 if hasattr(c, "const_mmap"):
-                    v_i = constraint_v[i]
-                    scale = (1 - c.const_coeff) / c.const_coeff
-                    presub_exps = list(c.unsubbed[0].hmap)
-                    for const_presub_idx, pct in c.const_mmap.items():
-                        for vk, exp in presub_exps[const_presub_idx].items():
-                            if vk not in self.varcols:
-                                const_senss[vk] -= v_i * pct * scale * exp
+                    self._apply_const_mmap_correction(const_senss, c, constraint_v[i])
 
-        # Direct contributions when A or B are constants (no linear system needed)
-        if A_vk not in self.varcols:
-            const_senss[A_vk] += A_val
-        if B_vk not in self.varcols:
-            const_senss[B_vk] -= B_val
+        # Direct contributions when plus_var or minus_var are constants
+        if plus_vk not in self.varcols:
+            const_senss[plus_vk] += plus_val
+        if minus_vk not in self.varcols:
+            const_senss[minus_vk] -= minus_val
 
         # Chain rule for linked constants (same pattern as _calculate_sensitivities).
         # pywarnings suppresses RuntimeWarning from 0-division when val == 0.
@@ -691,12 +703,12 @@ class GeometricProgram:
                     dlogv_dlogc = dv_dc * self.substitutions[linked_c] / val
                     const_senss[linked_c] += d_margin_d_logv * dlogv_dlogc
 
-        units = A_vk.unitstr() if A_vk.units else ""
+        units = plus_vk.unitstr() if plus_vk.units else ""
         return MarginSolution(
             name=margin_obj.name,
-            value=A_val - B_val,
-            plus_value=A_val,
-            minus_value=B_val,
+            value=plus_val - minus_val,
+            plus_value=plus_val,
+            minus_value=minus_val,
             units=units,
             sensitivities=dict(const_senss),
         )

--- a/gpkit/programs/gp.py
+++ b/gpkit/programs/gp.py
@@ -703,6 +703,15 @@ class GeometricProgram:
                     dlogv_dlogc = dv_dc * self.substitutions[linked_c] / val
                     const_senss[linked_c] += d_margin_d_logv * dlogv_dlogc
 
+        # Convert ∂(margin)/∂log(c) → ∂(margin)/∂c by dividing by c*.
+        # This gives physically dimensioned sensitivities in [margin_units/c_units].
+        with pywarnings.catch_warnings():
+            pywarnings.simplefilter("ignore")
+            for vk in list(const_senss):
+                c_val = float(self.substitutions.get(vk, 0))
+                if c_val:
+                    const_senss[vk] /= c_val
+
         units = plus_vk.unitstr() if plus_vk.units else ""
         return MarginSolution(
             name=margin_obj.name,

--- a/gpkit/programs/gp.py
+++ b/gpkit/programs/gp.py
@@ -541,19 +541,21 @@ class GeometricProgram:
 
         ac = np.vstack(ac_rows)  # (n_tight × n_vars)
 
-        # Each column of W is a unit vector selecting one free variable.
-        W = np.zeros((n_vars, len(valid_vks)))
+        # Each column selects one free variable (unit vector at its index).
+        weight_cols = np.zeros((n_vars, len(valid_vks)))
         for j, vk in enumerate(valid_vks):
-            W[self.varcols[vk], j] = 1.0
+            weight_cols[self.varcols[vk], j] = 1.0
 
-        V, _, _, _ = np.linalg.lstsq(ac.T, W, rcond=None)
+        adjoint_cols, _, _, _ = np.linalg.lstsq(ac.T, weight_cols, rcond=None)
 
         for j, vk in enumerate(valid_vks):
             qnu = np.zeros(n_constr_mono)
             cv = np.zeros(n_constr)
             for i, (q_start, q_end, lambda_i, constr_i) in enumerate(tight_slices):
-                qnu[q_start:q_end] = (V[i, j] / lambda_i) * nu_constr[q_start:q_end]
-                cv[constr_i] = V[i, j]
+                qnu[q_start:q_end] = (adjoint_cols[i, j] / lambda_i) * nu_constr[
+                    q_start:q_end
+                ]
+                cv[constr_i] = adjoint_cols[i, j]
             result[vk] = (qnu, cv)
 
         return result

--- a/gpkit/programs/gp.py
+++ b/gpkit/programs/gp.py
@@ -501,13 +501,26 @@ class GeometricProgram:
         return cost_senss, gpv_ss, absv_ss, m_senss, constraint_senss
 
     def _compute_free_var_adjoints(self, nu, free_varkeys):
-        """Compute per-variable adjoint qnu vectors via one batched linear solve.
+        """Compute per-variable adjoint vectors for each vk in free_varkeys.
 
-        For each vk in free_varkeys, solves ac^T v_j = e_j (unit vector at
-        varcols[vk]) so that ∂x_j*/∂log(c) can be accumulated from qnu_j.
+        Three phases:
 
-        ac (n_tight × n_vars) has one row per active constraint:
-        ac[i,:] = nu_i @ A_i / lambda_i.  Slack constraints are skipped.
+        1. Build ac (n_tight × n_vars): one row per active constraint,
+           ac[i,:] = (A_i^T nu_i) / lambda_i.  Slack constraints are skipped.
+           This loop is unavoidable — m_idxs is an irregular per-constraint
+           slice structure that must be read entry by entry.
+
+        2. Batched linear solve: ac^T V = W, where each column of W is a unit
+           vector selecting one free variable.  One lstsq call solves all
+           free_varkeys simultaneously.  adjoint_cols[i,j] is how much
+           tight constraint i's activity shifts per unit change in log(x_j*).
+
+        3. Scatter results back to monomial indexing: adjoint_cols lives in
+           "one row per tight constraint" space; qnu must be in "one entry per
+           monomial" space.  The scatter loop distributes each constraint's
+           adjoint value into its monomial slice, weighted by nu_i / lambda_i.
+           (Could be vectorized via a precomputed monomial→tight-constraint
+           index array if extended to many free variables.)
 
         Returns {VarKey: (qnu_array, constraint_v_array)} for each vk in
         free_varkeys that is present in self.varcols.

--- a/gpkit/programs/gp.py
+++ b/gpkit/programs/gp.py
@@ -21,7 +21,7 @@ from ..exceptions import (
     UnknownInfeasible,
 )
 from ..nomials.map import NomialMap
-from ..solutions import Sensitivities, Solution, _WeakModelRef
+from ..solutions import MarginSolution, Sensitivities, Solution, _WeakModelRef
 from ..util.repr_conventions import lineagestr
 from ..util.small_classes import CootMatrix, FixedScalar, Numbers, SolverLog
 from ..util.small_scripts import appendsolwarning, initsolwarning
@@ -500,6 +500,207 @@ class GeometricProgram:
 
         return cost_senss, gpv_ss, absv_ss, m_senss, constraint_senss
 
+    def _compute_variable_sensitivities(self, nu, primal_weights):
+        """Compute ∂(Σ w_i x_i)/∂log(c_m) via one linear solve.
+
+        Parameters
+        ----------
+        nu : array
+            Full dual variable vector (length = total monomials, including cost).
+        primal_weights : dict
+            {VarKey: float} — coefficient of each free variable in the quantity
+            of interest.  E.g. {A_key: A_val, B_key: -B_val} for margin A − B.
+
+        Returns
+        -------
+        (v_prime, qnu) : (np.ndarray, np.ndarray)
+            v_prime — solution to A_c^T v' = w, one entry per tight constraint
+            qnu     — sensitivity weight per constraint monomial:
+                      qnu[k] = (v'[i] / lambda_i) * nu_constr[k],
+                      where i is the tight-constraint index for monomial k and
+                      lambda_i = sum(nu_constr[monomials of constraint i]).
+
+        Notes
+        -----
+        A_c (n_tight × n_vars) is the matrix of nu-weighted average exponents,
+        one row per tight constraint: A_c[i,:] = nu_i @ A_i / lambda_i.
+        Slack constraints (lambda_i ≈ 0) are skipped; they contribute nothing.
+        """
+        obj_end = self.data.m_idxs[0].stop
+        A_constr = self.data.A.tocsr()[obj_end:, :]  # sparse (n_constr_mono, n_vars)
+        nu_constr = np.asarray(nu[obj_end:], dtype=float)
+        n_vars = len(self.vars)
+
+        # Build A_c: one dense row per tight constraint.
+        # A_c[i,:] = nu_i @ A_i / lambda_i  (nu-weighted average of exponents).
+        # Relative threshold: skip constraints whose dual weight is negligible compared
+        # to the overall dual magnitude (cvxopt solver tolerance ≈ 1e-5).
+        nu_scale = float(nu_constr.sum()) + 1.0
+
+        a_c_rows = []
+        tight_slices = (
+            []
+        )  # (q_start, q_end, lambda_i, constr_i) for each tight constraint
+        for constr_i, m_idx in enumerate(self.data.m_idxs[1:]):
+            q_start = m_idx.start - obj_end
+            q_end = m_idx.stop - obj_end
+            nu_i = nu_constr[q_start:q_end]
+            lambda_i = float(nu_i.sum())
+            if lambda_i < 1e-5 * nu_scale:
+                continue
+            # A_constr[q_start:q_end, :].T @ nu_i  →  dense (n_vars,)
+            a_c_row = np.asarray(A_constr[q_start:q_end, :].T.dot(nu_i)).ravel()
+            a_c_rows.append(a_c_row / lambda_i)
+            tight_slices.append((q_start, q_end, lambda_i, constr_i))
+
+        n_constr = len(self.data.m_idxs) - 1
+        qnu = np.zeros(len(nu_constr))
+        constraint_v = np.zeros(n_constr)
+        if not a_c_rows:
+            return np.zeros(0), qnu, constraint_v
+
+        A_c = np.vstack(a_c_rows)  # (n_tight × n_vars) dense
+
+        w = np.zeros(n_vars)
+        for vk, coeff in primal_weights.items():
+            if vk in self.varcols:
+                w[self.varcols[vk]] = coeff
+
+        # Solve A_c^T v' = w: (n_vars equations, n_tight unknowns)
+        v_prime, _, _, _ = np.linalg.lstsq(A_c.T, w, rcond=None)
+
+        # For each tight constraint i, broadcast v'_i / lambda_i across its
+        # constituent monomials, weighted by nu_constr.  Also record v'_i by
+        # constraint index so callers can apply const_mmap corrections.
+        for j, (q_start, q_end, lambda_i, constr_i) in enumerate(tight_slices):
+            qnu[q_start:q_end] = (v_prime[j] / lambda_i) * nu_constr[q_start:q_end]
+            constraint_v[constr_i] = v_prime[j]
+
+        return v_prime, qnu, constraint_v
+
+    def _accumulate_posy_const_sens(self, const_senss, hmap_qnu, c):
+        """Accumulate ∂(A−B)/∂log(c_m) contributions from one PosynomialInequality.
+
+        The inner loops (pmap entries × exponent dict entries) are O(1) and
+        O(2-5) per monomial respectively in typical engineering models.
+        """
+        if not hasattr(c, "pmap"):
+            raise RuntimeError(
+                f"Constraint {c!r} is missing pmap.  "
+                "_compute_margin_sensitivity must be called before "
+                "_calculate_sensitivities (which deletes pmap).  "
+                "See issue #200."
+            )
+        presub_exps = list(c.unsubbed[0].hmap)
+        for k, qnu_j in enumerate(hmap_qnu):
+            for presub_idx, fraction in c.pmap[k].items():
+                for vk, exp in presub_exps[presub_idx].items():
+                    if vk not in self.varcols:  # constant VarKey
+                        const_senss[vk] -= qnu_j * fraction * exp
+
+    def _compute_margin_sensitivity(self, nu, varvals, margin_obj):
+        """Compute ∂(A−B)/∂log(c) for every constant c via one linear solve.
+
+        Must be called BEFORE _calculate_sensitivities() because pmap is deleted
+        there.  See GitHub issue #200 for the pmap mutation discussion.
+
+        Parameters
+        ----------
+        nu : array
+            Full dual variable vector from the solver.
+        varvals : VarMap
+            Combined free-variable primal values and substituted constants.
+        margin_obj : MarginObjective
+            Specifies plus_var (A) and minus_var (B).
+
+        Returns
+        -------
+        MarginSolution
+        """
+        A_vk = getattr(margin_obj.plus_var, "key", margin_obj.plus_var)
+        B_vk = getattr(margin_obj.minus_var, "key", margin_obj.minus_var)
+        A_val = float(varvals.get(A_vk, 0))
+        B_val = float(varvals.get(B_vk, 0))
+
+        primal_weights = {}
+        if A_vk in self.varcols:
+            primal_weights[A_vk] = A_val
+        if B_vk in self.varcols:
+            primal_weights[B_vk] = -B_val
+
+        _, qnu, constraint_v = self._compute_variable_sensitivities(nu, primal_weights)
+
+        # Accumulate ∂(A−B)/∂log(c_m) = −Σ_j qnu_j * e_{jm} for each constant c_m.
+        # Slack constraints self-eliminate: complementarity gives nu_k = 0 for
+        # inactive constraints, so their qnu is zero and they contribute nothing.
+        obj_end = self.data.m_idxs[0].stop
+        const_senss = defaultdict(float)
+        meq_unsubbed_idx = defaultdict(
+            int
+        )  # which unsubbed to use per MonomialEquality
+
+        for i, hmap in enumerate(self.hmaps[1:]):
+            c = hmap
+            while getattr(c, "parent", None) is not None:
+                c = c.parent
+
+            q_start = self.data.m_idxs[i + 1].start - obj_end
+            q_end = self.data.m_idxs[i + 1].stop - obj_end
+            hmap_qnu = qnu[q_start:q_end]
+
+            if getattr(hmap, "from_meq", False):
+                # MonomialEquality emits two hmaps sharing one parent object.
+                # Track which unsubbed index belongs to each (first=0, second=1).
+                parent_id = id(c)
+                unsubbed_idx = meq_unsubbed_idx[parent_id]
+                meq_unsubbed_idx[parent_id] += 1
+                (presub_exp,) = c.unsubbed[unsubbed_idx].hmap
+                qnu_j = hmap_qnu[0]
+                for vk, exp in presub_exp.items():
+                    if vk not in self.varcols:
+                        const_senss[vk] -= qnu_j * exp
+            else:
+                self._accumulate_posy_const_sens(const_senss, hmap_qnu, c)
+                # const_mmap: constants absorbed into the constraint RHS shift the
+                # effective tight-condition when they're perturbed.  Apply the same
+                # correction that sens_from_dual uses, but scaled by v'_i instead
+                # of nu[i] (mirrors the pmap → qnu2 transform for the free-var terms).
+                if hasattr(c, "const_mmap"):
+                    v_i = constraint_v[i]
+                    scale = (1 - c.const_coeff) / c.const_coeff
+                    presub_exps = list(c.unsubbed[0].hmap)
+                    for const_presub_idx, pct in c.const_mmap.items():
+                        for vk, exp in presub_exps[const_presub_idx].items():
+                            if vk not in self.varcols:
+                                const_senss[vk] -= v_i * pct * scale * exp
+
+        # Direct contributions when A or B are constants (no linear system needed)
+        if A_vk not in self.varcols:
+            const_senss[A_vk] += A_val
+        if B_vk not in self.varcols:
+            const_senss[B_vk] -= B_val
+
+        # Chain rule for linked constants (same pattern as _calculate_sensitivities).
+        # pywarnings suppresses RuntimeWarning from 0-division when val == 0.
+        for v in list(vk for vk in const_senss if self.linked_derivs.get(vk)):
+            d_margin_d_logv = const_senss.pop(v)
+            val = np.array(self.substitutions[v])
+            for linked_c, dv_dc in self.linked_derivs[v].items():
+                with pywarnings.catch_warnings():
+                    pywarnings.simplefilter("ignore")
+                    dlogv_dlogc = dv_dc * self.substitutions[linked_c] / val
+                    const_senss[linked_c] += d_margin_d_logv * dlogv_dlogc
+
+        units = A_vk.unitstr() if A_vk.units else ""
+        return MarginSolution(
+            name=margin_obj.name,
+            value=A_val - B_val,
+            plus_value=A_val,
+            minus_value=B_val,
+            units=units,
+            sensitivities=dict(const_senss),
+        )
+
     def _compile_result(self, solver_out):
         primal = solver_out.x
         if len(self.vars) != len(primal):
@@ -510,6 +711,15 @@ class GeometricProgram:
         warnings = {}
         if self.integersolve or self.choicevaridxs:
             warnings.update(self._handle_choicevars(solver_out))
+
+        # Compute margin sensitivity BEFORE _calculate_sensitivities(), which deletes
+        # pmap on each constraint.  See issue #200 for the pmap mutation discussion.
+        margin_obj = getattr(self.model, "margin_objective", None)
+        derived = None
+        if margin_obj is not None:
+            derived = self._compute_margin_sensitivity(
+                solver_out.nu, varvals, margin_obj
+            )
 
         _, gpv_ss, absv_ss, m_senss, constraint_senss = self._calculate_sensitivities(
             solver_out.la, solver_out.nu, varvals
@@ -526,6 +736,7 @@ class GeometricProgram:
                 variablerisk=VarMap(absv_ss),
             ),
             meta={"soltime": solver_out.meta["soltime"], "warnings": warnings},
+            derived=derived,
         )
         result.meta["cost function"] = self.cost
         result.meta["model"] = _WeakModelRef(self.model)

--- a/gpkit/programs/sgp.py
+++ b/gpkit/programs/sgp.py
@@ -209,6 +209,9 @@ solutions and can be solved with 'Model.solve()'.""")
                 )
                 rel_improvement = cost = None
         # solved successfully!
+        # Wire model so generate_result can find margin_objective.
+        # Long-term fix: pass margin_obj explicitly (see issue #143).
+        gp.model = self.model
         self.result = gp.generate_result(solver_out, verbosity=verbosity - 3)
         self.result.meta["soltime"] = time() - starttime
         if verbosity > 1:

--- a/gpkit/solutions.py
+++ b/gpkit/solutions.py
@@ -114,12 +114,16 @@ class MarginSolution:
             label = "by |GP sensitivity|"
             items = sorted(
                 self.sensitivities.items(),
-                key=lambda kv: (-abs(cost_sens.get(kv[0], 0)), kv[0].ref),
+                key=lambda kv: (
+                    -float(f"{abs(cost_sens.get(kv[0], 0)):.4g}"),
+                    kv[0].ref,
+                ),
             )
         else:
             label = "most negative first"
             items = sorted(
-                self.sensitivities.items(), key=lambda kv: (kv[1], kv[0].ref)
+                self.sensitivities.items(),
+                key=lambda kv: (float(f"{kv[1]:.4g}"), kv[0].ref),
             )
         lines.append(f"  ∂({self.name})/∂c [{label}]:")
         names = display_names([vk for vk, _ in items])

--- a/gpkit/solutions.py
+++ b/gpkit/solutions.py
@@ -81,6 +81,33 @@ class Sensitivities:
         raise NotImplementedError
 
 
+@dataclass(frozen=True, slots=True)
+class MarginSolution:
+    "Value and per-constant sensitivities for a MarginObjective"
+
+    name: str
+    value: float  # A* − B*
+    plus_value: float  # A*
+    minus_value: float  # B*
+    units: str  # unit string from plus_var.key.units (may be empty)
+    sensitivities: dict  # {VarKey: ∂(A−B)/∂log(c)} for each constant
+
+    def table(self) -> str:
+        "Format sensitivities sorted most-negative first."
+        u = f" {self.units}" if self.units else ""
+        lines = [
+            f"\n{self.name}: {self.value:.4g}{u}"
+            f"  (A={self.plus_value:.4g}{u}, B={self.minus_value:.4g}{u})",
+        ]
+        if not self.sensitivities:
+            return "\n".join(lines)
+        lines.append(f"  ∂({self.name})/∂log(c) [most negative first]:")
+        for vk, s in sorted(self.sensitivities.items(), key=lambda kv: kv[1]):
+            pct = 100 * s / self.value if self.value else 0
+            lines.append(f"    {vk.name:20s}  {s:+.4g}{u}  ({pct:+.1f}%)")
+        return "\n".join(lines)
+
+
 SUMMARY_TABLES = ("sweeps", "cost", "warnings", "solution")
 
 
@@ -94,6 +121,7 @@ class Solution:
     sens: Sensitivities
     # program : GP
     meta: dict
+    derived: "MarginSolution | None" = None
 
     @property
     def variables(self):
@@ -172,6 +200,8 @@ class Solution:
     def summary(self, **kwargs) -> str:
         "Print a summary table of this Solution"
         lines = self.cost_breakdown() + self.model_sens_breakdown() + [""]
+        if self.derived is not None:
+            lines.append(self.derived.table())
         table = printing.table(self, tables=SUMMARY_TABLES, **kwargs)
         return "\n".join(lines) + table
 
@@ -180,6 +210,8 @@ class Solution:
         lines = []
         if "tables" not in kwargs:  # don't add breakdowns if tables custom
             lines += self.cost_breakdown() + self.model_sens_breakdown() + [""]
+            if self.derived is not None:
+                lines.append(self.derived.table())
         return "\n".join(lines) + printing.table(self, **kwargs)
 
     def budget(self, var, display_units=None, depth=float("inf")):

--- a/gpkit/solutions.py
+++ b/gpkit/solutions.py
@@ -90,21 +90,26 @@ class MarginSolution:
     plus_value: float  # A*
     minus_value: float  # B*
     units: str  # unit string from plus_var.key.units (may be empty)
-    sensitivities: dict  # {VarKey: ∂(A−B)/∂log(c)} for each constant
+    sensitivities: dict  # {VarKey: ∂(margin)/∂c} for each constant
 
     def table(self) -> str:
         "Format sensitivities sorted most-negative first."
         u = f" {self.units}" if self.units else ""
         lines = [
             f"\n{self.name}: {self.value:.4g}{u}"
-            f"  (A={self.plus_value:.4g}{u}, B={self.minus_value:.4g}{u})",
+            f"  (plus={self.plus_value:.4g}{u}, minus={self.minus_value:.4g}{u})",
         ]
         if not self.sensitivities:
             return "\n".join(lines)
-        lines.append(f"  ∂({self.name})/∂log(c) [most negative first]:")
+        lines.append(f"  ∂({self.name})/∂c [most negative first]:")
         for vk, s in sorted(self.sensitivities.items(), key=lambda kv: kv[1]):
-            pct = 100 * s / self.value if self.value else 0
-            lines.append(f"    {vk.name:20s}  {s:+.4g}{u}  ({pct:+.1f}%)")
+            if self.units and vk.units:
+                c_units = vk.unitstr()
+                c_fmt = f"({c_units})" if "/" in c_units else c_units
+                su = f" {self.units}/{c_fmt}"
+            else:
+                su = u
+            lines.append(f"    {vk.name:20s}  {s:+.4g}{su}")
         return "\n".join(lines)
 
 

--- a/gpkit/solutions.py
+++ b/gpkit/solutions.py
@@ -92,8 +92,17 @@ class MarginSolution:
     units: str  # unit string from plus_var.key.units (may be empty)
     sensitivities: dict  # {VarKey: ∂(margin)/∂c} for each constant
 
-    def table(self) -> str:
-        "Format sensitivities sorted most-negative first."
+    def table(self, cost_sens=None) -> str:
+        """Format sensitivities, ordered by |GP cost sensitivity| when provided.
+
+        Parameters
+        ----------
+        cost_sens : dict, optional
+            {VarKey: ∂log(cost)/∂log(c)} from sol.sens.variables.  When given,
+            rows are ordered by descending |cost_sens| — a dimensionless,
+            unit-invariant ranking of each constant's influence.  When omitted,
+            rows are ordered by the margin sensitivity value (most negative first).
+        """
         u = f" {self.units}" if self.units else ""
         lines = [
             f"\n{self.name}: {self.value:.4g}{u}"
@@ -101,8 +110,18 @@ class MarginSolution:
         ]
         if not self.sensitivities:
             return "\n".join(lines)
-        lines.append(f"  ∂({self.name})/∂c [most negative first]:")
-        for vk, s in sorted(self.sensitivities.items(), key=lambda kv: kv[1]):
+        if cost_sens is not None:
+            label = "by |GP sensitivity|"
+            items = sorted(
+                self.sensitivities.items(),
+                key=lambda kv: abs(cost_sens.get(kv[0], 0)),
+                reverse=True,
+            )
+        else:
+            label = "most negative first"
+            items = sorted(self.sensitivities.items(), key=lambda kv: kv[1])
+        lines.append(f"  ∂({self.name})/∂c [{label}]:")
+        for vk, s in items:
             if self.units and vk.units:
                 c_units = vk.unitstr()
                 c_fmt = f"({c_units})" if "/" in c_units else c_units

--- a/gpkit/solutions.py
+++ b/gpkit/solutions.py
@@ -11,7 +11,7 @@ from .breakdowns import bdtable_gen
 from .budgets import build_budget
 from .units import Quantity
 from .varkey import VarKey
-from .varmap import VarMap
+from .varmap import VarMap, display_names
 
 
 class _WeakModelRef:
@@ -121,6 +121,7 @@ class MarginSolution:
             label = "most negative first"
             items = sorted(self.sensitivities.items(), key=lambda kv: kv[1])
         lines.append(f"  ∂({self.name})/∂c [{label}]:")
+        names = display_names([vk for vk, _ in items])
         for vk, s in items:
             if self.units and vk.units:
                 c_units = vk.unitstr()
@@ -128,7 +129,7 @@ class MarginSolution:
                 su = f" {self.units}/{c_fmt}"
             else:
                 su = u
-            lines.append(f"    {vk.name:20s}  {s:+.4g}{su}")
+            lines.append(f"    {names[vk]:20s}  {s:+.4g}{su}")
         return "\n".join(lines)
 
 

--- a/gpkit/solutions.py
+++ b/gpkit/solutions.py
@@ -114,12 +114,13 @@ class MarginSolution:
             label = "by |GP sensitivity|"
             items = sorted(
                 self.sensitivities.items(),
-                key=lambda kv: abs(cost_sens.get(kv[0], 0)),
-                reverse=True,
+                key=lambda kv: (-abs(cost_sens.get(kv[0], 0)), kv[0].ref),
             )
         else:
             label = "most negative first"
-            items = sorted(self.sensitivities.items(), key=lambda kv: kv[1])
+            items = sorted(
+                self.sensitivities.items(), key=lambda kv: (kv[1], kv[0].ref)
+            )
         lines.append(f"  ∂({self.name})/∂c [{label}]:")
         names = display_names([vk for vk, _ in items])
         for vk, s in items:

--- a/gpkit/tests/test_margin_objective.py
+++ b/gpkit/tests/test_margin_objective.py
@@ -251,8 +251,6 @@ def test_margin_solution_table():
 
 def test_from_ir_preserves_margin_objective():
     """Model.from_ir(model.to_ir()) reconstructs a model w/ margin_objective intact."""
-    from gpkit import Model
-
     model = SimpleMarginModel()
     ir = model.to_ir()
     assert "margin_objective" in ir

--- a/gpkit/tests/test_margin_objective.py
+++ b/gpkit/tests/test_margin_objective.py
@@ -66,18 +66,21 @@ class ConstMapModel(Model):
 
 
 def _fd_margin_sens(model_cls, const_name, eps=0.005):
-    """Return finite-difference ∂(margin)/∂log(c) for constant `const_name`."""
+    """Return finite-difference ∂(margin)/∂c for constant `const_name`."""
+    c0 = None
 
     def margin_at(factor):
+        nonlocal c0
         m = model_cls()
         for vk in m.substitutions:
             if vk.name == const_name:
+                c0 = float(m.substitutions[vk])
                 m.substitutions[vk] = m.substitutions[vk] * factor
                 break
-        sol = m.solve(verbosity=0)
-        return sol.derived.value
+        return m.solve(verbosity=0).derived.value
 
-    return (margin_at(1 + eps) - margin_at(1 - eps)) / (2 * eps)
+    fd_log = (margin_at(1 + eps) - margin_at(1 - eps)) / (2 * eps)
+    return fd_log / c0
 
 
 # ---------------------------------------------------------------------------
@@ -95,17 +98,16 @@ def test_simple_margin_value():
 
 
 def test_simple_margin_sensitivities_analytical():
-    """Analytical check of ∂margin/∂log(c) for SimpleMarginModel.
+    """Analytical check of ∂margin/∂c for SimpleMarginModel.
 
     B* = c_frac * A_allow = 80, margin = A_allow - B* = 20.
-    For A_allow: direct +A_val = +100, but B* = c*A also increases (linear in A),
-    so the constraint contributes -80, netting +20.
-    For c_frac: B* = c*A is tight, contribution -80.
+    ∂(margin)/∂A_allow: log-sens = +20 kg, divided by A_allow=100 kg → +0.2.
+    ∂(margin)/∂c_frac:  log-sens = -80 kg, divided by c_frac=0.8 → -100 kg.
     """
     sol = SimpleMarginModel().solve(verbosity=0)
     senss = {vk.name: v for vk, v in sol.derived.sensitivities.items()}
-    assert abs(senss["A_allow"] - 20.0) < 1e-4
-    assert abs(senss["c_frac"] - (-80.0)) < 1e-4
+    assert abs(senss["A_allow"] - 0.2) < 1e-6
+    assert abs(senss["c_frac"] - (-100.0)) < 1e-4
 
 
 def test_simple_margin_sensitivities_fd():
@@ -190,10 +192,22 @@ def test_growth_allowance_margin_fd():
                 break
         return m.solve(verbosity=0).derived.value
 
+    def c0_for(src_vk):
+        key = stable_key(src_vk)
+        m = GrowthAllowance()
+        for vk in m.substitutions:
+            if stable_key(vk) == key:
+                return float(m.substitutions[vk])
+        return 1.0
+
     sol = GrowthAllowance().solve(verbosity=0)
     eps = 0.005
     for vk, sens in sol.derived.sensitivities.items():
-        fd = (margin_at_factor(vk, 1 + eps) - margin_at_factor(vk, 1 - eps)) / (2 * eps)
+        c0 = c0_for(vk)
+        fd_log = (margin_at_factor(vk, 1 + eps) - margin_at_factor(vk, 1 - eps)) / (
+            2 * eps
+        )
+        fd = fd_log / c0
         assert (
             abs(sens - fd) / max(abs(sens), 1e-10) < 1e-2
         ), f"FD check failed for {vk.name} ({vk.ref}): computed={sens:.4g}, fd={fd:.4g}"

--- a/gpkit/tests/test_margin_objective.py
+++ b/gpkit/tests/test_margin_objective.py
@@ -12,30 +12,30 @@ class SimpleMarginModel(Model):
     """B >= c * A_allow, cost = B/A, margin = A_allow - B."""
 
     def setup(self):
-        A = Variable("A_allow", 100.0, "kg", "Allowable mass")
-        B = Variable("B_mass", "kg", "System mass")
+        a = Variable("A_allow", 100.0, "kg", "Allowable mass")
+        b = Variable("B_mass", "kg", "System mass")
         c = Variable("c_frac", 0.8, "", "Mass fraction")
-        self.cost = B / A
+        self.cost = b / a
         self.margin_objective = MarginObjective(
             name="mass margin",
-            plus_var=A,
-            minus_var=B,
+            plus_var=a,
+            minus_var=b,
         )
-        return [B >= c * A]
+        return [b >= c * a]
 
 
 class BothFreeModel(Model):
     """A and B both free, each bounded by separate constants."""
 
     def setup(self):
-        A = Variable("A", "kg", "allowable")
-        B = Variable("B", "kg", "actual")
-        A_max = Variable("A_max", 120.0, "kg", "A upper bound")
-        B_min = Variable("B_min", 50.0, "kg", "B lower bound")
+        a = Variable("A", "kg", "allowable")
+        b = Variable("B", "kg", "actual")
+        a_max = Variable("A_max", 120.0, "kg", "A upper bound")
+        b_min = Variable("B_min", 50.0, "kg", "B lower bound")
         alpha = Variable("alpha", 1.5, "", "A–B ratio floor")
-        self.cost = B / A
-        self.margin_objective = MarginObjective("gap", plus_var=A, minus_var=B)
-        return [A <= A_max, B >= B_min, A >= alpha * B]
+        self.cost = b / a
+        self.margin_objective = MarginObjective("gap", plus_var=a, minus_var=b)
+        return [a <= a_max, b >= b_min, a >= alpha * b]
 
 
 class ConstMapModel(Model):
@@ -48,16 +48,16 @@ class ConstMapModel(Model):
     """
 
     def setup(self):
-        P_prop = Variable("P_prop", "W", "propulsion power")
-        P_avionics = Variable("P_avionics", 50.0, "W", "avionics power (fixed)")
-        P_max = Variable("P_max", 200.0, "W", "total power limit")
-        self.cost = P_max / P_prop  # minimize budget/propulsion → P_prop at upper bound
+        p_prop = Variable("P_prop", "W", "propulsion power")
+        p_avionics = Variable("P_avionics", 50.0, "W", "avionics power (fixed)")
+        p_max = Variable("P_max", 200.0, "W", "total power limit")
+        self.cost = p_max / p_prop  # minimize budget/propulsion → p_prop at upper bound
         self.margin_objective = MarginObjective(
             "power margin",
-            plus_var=P_max,
-            minus_var=P_prop,
+            plus_var=p_max,
+            minus_var=p_prop,
         )
-        return [P_prop + P_avionics <= P_max]
+        return [p_prop + p_avionics <= p_max]
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +154,8 @@ def test_no_margin_objective():
     """Models without margin_objective have sol.derived is None."""
 
     class Plain(Model):
+        """Minimal model with no margin_objective."""
+
         def setup(self):
             x = Variable("x")
             self.cost = x
@@ -213,6 +215,8 @@ def test_to_ir_no_margin_objective():
     """to_ir() has no margin_objective key for plain models."""
 
     class Plain(Model):
+        """Minimal model with no margin_objective."""
+
         def setup(self):
             x = Variable("x")
             self.cost = x

--- a/gpkit/tests/test_margin_objective.py
+++ b/gpkit/tests/test_margin_objective.py
@@ -247,3 +247,21 @@ def test_margin_solution_table():
     assert isinstance(table, str)
     assert "mass margin" in table
     assert "A_allow" in table or "c_frac" in table
+
+
+def test_from_ir_preserves_margin_objective():
+    """Model.from_ir(model.to_ir()) reconstructs a model w/ margin_objective intact."""
+    from gpkit import Model
+
+    model = SimpleMarginModel()
+    ir = model.to_ir()
+    assert "margin_objective" in ir
+
+    model2 = Model.from_ir(ir)
+    assert model2.margin_objective is not None
+    assert model2.margin_objective.name == "mass margin"
+
+    sol = model2.solve(verbosity=0)
+    assert sol.derived is not None
+    assert sol.derived.name == "mass margin"
+    assert abs(sol.derived.value - 20.0) < 1e-4

--- a/gpkit/tests/test_margin_objective.py
+++ b/gpkit/tests/test_margin_objective.py
@@ -1,0 +1,231 @@
+"Tests for MarginObjective and MarginSolution"
+
+from gpkit import MarginObjective, Model, Variable
+from gpkit.examples.growth_allowance import GrowthAllowance
+
+# ---------------------------------------------------------------------------
+# Simple models used across multiple tests
+# ---------------------------------------------------------------------------
+
+
+class SimpleMarginModel(Model):
+    """B >= c * A_allow, cost = B/A, margin = A_allow - B."""
+
+    def setup(self):
+        A = Variable("A_allow", 100.0, "kg", "Allowable mass")
+        B = Variable("B_mass", "kg", "System mass")
+        c = Variable("c_frac", 0.8, "", "Mass fraction")
+        self.cost = B / A
+        self.margin_objective = MarginObjective(
+            name="mass margin",
+            plus_var=A,
+            minus_var=B,
+        )
+        return [B >= c * A]
+
+
+class BothFreeModel(Model):
+    """A and B both free, each bounded by separate constants."""
+
+    def setup(self):
+        A = Variable("A", "kg", "allowable")
+        B = Variable("B", "kg", "actual")
+        A_max = Variable("A_max", 120.0, "kg", "A upper bound")
+        B_min = Variable("B_min", 50.0, "kg", "B lower bound")
+        alpha = Variable("alpha", 1.5, "", "A–B ratio floor")
+        self.cost = B / A
+        self.margin_objective = MarginObjective("gap", plus_var=A, minus_var=B)
+        return [A <= A_max, B >= B_min, A >= alpha * B]
+
+
+class ConstMapModel(Model):
+    """Constraint with an additive constant term → triggers const_mmap.
+
+    P_prop + P_avionics <= P_max, margin = P_max - P_prop.
+    After substitution P_avionics and P_max are both constants, so the
+    pure-constant monomial P_avionics/P_max is moved to const_mmap.
+    Cost P_max/P_prop (budget per propulsion) drives P_prop to its upper bound.
+    """
+
+    def setup(self):
+        P_prop = Variable("P_prop", "W", "propulsion power")
+        P_avionics = Variable("P_avionics", 50.0, "W", "avionics power (fixed)")
+        P_max = Variable("P_max", 200.0, "W", "total power limit")
+        self.cost = P_max / P_prop  # minimize budget/propulsion → P_prop at upper bound
+        self.margin_objective = MarginObjective(
+            "power margin",
+            plus_var=P_max,
+            minus_var=P_prop,
+        )
+        return [P_prop + P_avionics <= P_max]
+
+
+# ---------------------------------------------------------------------------
+# Helper: solve with perturbed constant for finite-difference validation
+# ---------------------------------------------------------------------------
+
+
+def _fd_margin_sens(model_cls, const_name, eps=0.005):
+    """Return finite-difference ∂(margin)/∂log(c) for constant `const_name`."""
+
+    def margin_at(factor):
+        m = model_cls()
+        for vk in m.substitutions:
+            if vk.name == const_name:
+                m.substitutions[vk] = m.substitutions[vk] * factor
+                break
+        sol = m.solve(verbosity=0)
+        return sol.derived.value
+
+    return (margin_at(1 + eps) - margin_at(1 - eps)) / (2 * eps)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_simple_margin_value():
+    """A* = 100, B* = 80 → margin = 20 kg."""
+    sol = SimpleMarginModel().solve(verbosity=0)
+    assert sol.derived is not None
+    assert abs(sol.derived.value - 20.0) < 1e-4
+    assert abs(sol.derived.plus_value - 100.0) < 1e-4
+    assert abs(sol.derived.minus_value - 80.0) < 1e-4
+
+
+def test_simple_margin_sensitivities_analytical():
+    """Analytical check of ∂margin/∂log(c) for SimpleMarginModel.
+
+    B* = c_frac * A_allow = 80, margin = A_allow - B* = 20.
+    For A_allow: direct +A_val = +100, but B* = c*A also increases (linear in A),
+    so the constraint contributes -80, netting +20.
+    For c_frac: B* = c*A is tight, contribution -80.
+    """
+    sol = SimpleMarginModel().solve(verbosity=0)
+    senss = {vk.name: v for vk, v in sol.derived.sensitivities.items()}
+    assert abs(senss["A_allow"] - 20.0) < 1e-4
+    assert abs(senss["c_frac"] - (-80.0)) < 1e-4
+
+
+def test_simple_margin_sensitivities_fd():
+    """Finite-difference cross-check for SimpleMarginModel."""
+    sol = SimpleMarginModel().solve(verbosity=0)
+    for vk, sens in sol.derived.sensitivities.items():
+        fd = _fd_margin_sens(SimpleMarginModel, vk.name)
+        assert (
+            abs(sens - fd) / max(abs(sens), 1e-10) < 1e-3
+        ), f"FD check failed for {vk.name}: computed={sens:.4g}, fd={fd:.4g}"
+
+
+def test_both_free_model_fd():
+    """Finite-difference cross-check for BothFreeModel."""
+    sol = BothFreeModel().solve(verbosity=0)
+    assert sol.derived is not None
+    for vk, sens in sol.derived.sensitivities.items():
+        fd = _fd_margin_sens(BothFreeModel, vk.name)
+        # Use absolute tolerance for near-zero sensitivities (slack constraints)
+        tol = max(1e-3 * max(abs(sens), abs(fd)), 1e-4)
+        assert (
+            abs(sens - fd) < tol
+        ), f"FD check failed for {vk.name}: computed={sens:.4g}, fd={fd:.4g}"
+
+
+def test_const_mmap_fd():
+    """Finite-difference check for const_mmap case (P_prop + P_avionics <= P_max).
+
+    P_avionics appears only in the const_mmap term after substitution.
+    Verify that sensitivities are correct (the const_mmap term self-eliminates
+    from the linear system but the primal values capture its effect correctly).
+    """
+    sol = ConstMapModel().solve(verbosity=0)
+    assert sol.derived is not None
+    # P_prop* = P_max - P_avionics = 150; margin = P_max - P_prop* = 50
+    assert abs(sol.derived.value - 50.0) < 1e-4
+    for vk, sens in sol.derived.sensitivities.items():
+        fd = _fd_margin_sens(ConstMapModel, vk.name)
+        tol = max(1e-3 * max(abs(sens), abs(fd)), 1e-4)
+        assert (
+            abs(sens - fd) < tol
+        ), f"FD check failed for {vk.name}: computed={sens:.4g}, fd={fd:.4g}"
+
+
+def test_no_margin_objective():
+    """Models without margin_objective have sol.derived is None."""
+
+    class Plain(Model):
+        def setup(self):
+            x = Variable("x")
+            self.cost = x
+            return [x >= 1]
+
+    sol = Plain().solve(verbosity=0)
+    assert sol.derived is None
+
+
+def test_growth_allowance_with_margin():
+    """GrowthAllowance example (with MarginObjective) solves and has valid derived."""
+    model = GrowthAllowance()
+    sol = model.solve(verbosity=0)
+    assert sol.derived is not None
+    assert sol.derived.name == "mass margin"
+    assert sol.derived.value > 0  # margin = budget - mass > 0
+
+
+def test_growth_allowance_margin_fd():
+    """Finite-difference cross-check for GrowthAllowance margin sensitivities."""
+
+    def stable_key(vk):
+        "Instance-stable identifier: strip root model instance counter."
+        return (vk.name, vk.lineage[1:])
+
+    def margin_at_factor(src_vk, factor):
+        key = stable_key(src_vk)
+        m = GrowthAllowance()
+        for vk in m.substitutions:
+            if stable_key(vk) == key:
+                m.substitutions[vk] = m.substitutions[vk] * factor
+                break
+        return m.solve(verbosity=0).derived.value
+
+    sol = GrowthAllowance().solve(verbosity=0)
+    eps = 0.005
+    for vk, sens in sol.derived.sensitivities.items():
+        fd = (margin_at_factor(vk, 1 + eps) - margin_at_factor(vk, 1 - eps)) / (2 * eps)
+        assert (
+            abs(sens - fd) / max(abs(sens), 1e-10) < 1e-2
+        ), f"FD check failed for {vk.name} ({vk.ref}): computed={sens:.4g}, fd={fd:.4g}"
+
+
+def test_to_ir_includes_margin_objective():
+    """to_ir() includes margin_objective dict with correct refs."""
+    model = SimpleMarginModel()
+    ir = model.to_ir()
+    assert "margin_objective" in ir
+    mo_ir = ir["margin_objective"]
+    assert mo_ir["name"] == "mass margin"
+    # plus_var ref should end with "A_allow"
+    assert "A_allow" in mo_ir["plus_var"]
+    assert "B_mass" in mo_ir["minus_var"]
+
+
+def test_to_ir_no_margin_objective():
+    """to_ir() has no margin_objective key for plain models."""
+
+    class Plain(Model):
+        def setup(self):
+            x = Variable("x")
+            self.cost = x
+            return [x >= 1]
+
+    ir = Plain().to_ir()
+    assert "margin_objective" not in ir
+
+
+def test_margin_solution_table():
+    """MarginSolution.table() returns a non-empty string."""
+    sol = SimpleMarginModel().solve(verbosity=0)
+    table = sol.derived.table()
+    assert isinstance(table, str)
+    assert "mass margin" in table
+    assert "A_allow" in table or "c_frac" in table


### PR DESCRIPTION
Adds a new `MarginObjective` formulation: a model formulated to minimize a ratio B/A when the actual objective is maximizing a margin A - B. This PR implements that formulation on `Model` as well as `Solution` including sensitivity tracking -- logspace partials of the margin objective wrt each constant.

**Usage**
```python
self.margin_objective = MarginObjective("mass margin", plus_var=m_budget, minus_var=self.m)
```
After solving, `sol.derived` is a `MarginSolution` with:
- `value` — the margin at optimum (e.g. `4.36 kg`)
- `plus_value` / `minus_value` — the individual terms
- `sensitivities` — `∂(margin)/∂log(c)` for every constant parameter, computed via one linear solve of the KKT stationarity conditions (not finite differences)
- `table()` — formatted sensitivity table, sorted most-negative first

**Changes**
- `gpkit/margin_objective.py` — new `MarginObjective` dataclass
- `gpkit/solutions.py` — new `MarginSolution` dataclass; `Solution.derived` field
- `gpkit/programs/gp.py` — `_compute_variable_sensitivities` and `_compute_margin_sensitivity`; wired into `_compile_result` for both GP and SGP
- `gpkit/model.py` / `to_ir()` — serializes `margin_objective` metadata
- `gpkit/examples/growth_allowance.py` — extended with a mass budget, `MarginObjective`, and `sol.derived.table()` output
- `gpkit/tests/test_margin_objective.py` — 11 tests covering value, analytical sensitivities, FD cross-checks (including `const_mmap` case), IR serialization, and the `GrowthAllowance` integration