### PR TITLE
Fix CI lint failures from ruff 0.16 default-rule expansion

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 # pylint: skip-file
-# -*- coding: utf-8 -*-
 #
 # gpkit documentation build configuration file, created by
 # sphinx-quickstart on Sun Oct 12 03:05:35 2014.

--- a/docs/source/modeling_conventions.md
+++ b/docs/source/modeling_conventions.md
@@ -80,7 +80,7 @@ mutating shared classes:
 
 ```python
 class Wing(Model):
-    sparModel = CapSpar     # override in subclasses to swap spar type
+    sparModel = CapSpar  # override in subclasses to swap spar type
     fillModel = WingCore
     skinModel = WingSkin
 
@@ -91,7 +91,8 @@ class Wing(Model):
             self.foam = self.fillModel(self.planform)
         ...
 
-class SolarWing(Wing):      # solar aircraft needs different structural layup
+
+class SolarWing(Wing):  # solar aircraft needs different structural layup
     sparModel = BoxSpar
     fillModel = None
     skinModel = WingSecondStruct
@@ -110,22 +111,22 @@ depth; the solver flattens the entire constraint tree regardless of nesting leve
 class Wing(Model):
     """Wing: planform geometry + structural sub-components"""
 
-    W    = Var("lbf", "wing weight")
-    mfac = Var("-",   "wing weight margin factor", value=1.2)
+    W = Var("lbf", "wing weight")
+    mfac = Var("-", "wing weight margin factor", value=1.2)
 
-    spar_model = CapSpar     # override in subclasses to swap spar type
+    spar_model = CapSpar  # override in subclasses to swap spar type
     fill_model = WingCore
     skin_model = WingSkin
 
     def setup(self, N=5):
-        self.planform = Planform(N)          # stored as self.attr — navigable from outside
+        self.planform = Planform(N)  # stored as self.attr — navigable from outside
         self.components = []
 
         if self.skin_model:
-            self.skin = self.skin_model(self.planform)       # planform passed in
+            self.skin = self.skin_model(self.planform)  # planform passed in
             self.components.append(self.skin)
         if self.spar_model:
-            self.spar = self.spar_model(N, self.planform)    # planform passed in
+            self.spar = self.spar_model(N, self.planform)  # planform passed in
             self.components.append(self.spar)
         if self.fill_model:
             self.foam = self.fill_model(self.planform)
@@ -149,9 +150,9 @@ A Perf model receiving a composite Component navigates as deep as needed:
 ```python
 class WingAero(Model):
     def setup(self, static, state):
-        AR   = static.planform.AR     # navigate into sub-component
+        AR = static.planform.AR  # navigate into sub-component
         cmac = static.planform.cmac
-        tau  = static.planform.tau
+        tau = static.planform.tau
         ...
 ```
 
@@ -207,7 +208,7 @@ class WingAero(Model):
         self.wing = wing
         self.state = state
 
-        c = wing.c           # Variable identity is the link — no explicit linking needed
+        c = wing.c  # Variable identity is the link — no explicit linking needed
         A = wing.A
         S = wing.S
         rho = state.rho
@@ -263,9 +264,9 @@ is the common case for a single-component Perf. Some simpler Perfs need only one
 
 ```python
 class BreguetEndurance(Model):
-    def setup(self, perf):        # only needs performance outputs, not the static component
-        BSFC    = perf.engine.BSFC
-        W_end   = perf.W_end
+    def setup(self, perf):  # only needs performance outputs, not the static component
+        BSFC = perf.engine.BSFC
+        W_end = perf.W_end
         W_start = perf.W_start
         ...
 ```
@@ -276,12 +277,13 @@ evaluating one subsystem at one condition — naturally have more arguments:
 ```python
 class MarsTransitInjection(Model):
     """Couples rocket capability to payload mass — neither is 'static' vs 'state'"""
+
     def setup(self, rocket, payload):
         self.burn = Burn(rocket, self.v_p)
         return [
             self.burn.m_prop <= rocket.m_prop_max,
             self.burn.m_cutoff >= payload.m + rocket.m_dry,
-            ...
+            ...,
         ]
 ```
 
@@ -303,6 +305,7 @@ associated Perf model:
 ```python
 class Wing(Model):
     ...
+
     def perf(self, state):
         return WingAero(self, state)
 ```
@@ -325,12 +328,13 @@ become N-element arrays — almost certainly wrong.
 # CORRECT — wing used but not owned; remains scalar when WingAero is vectorized
 class WingAero(Model):
     def setup(self, wing, state):
-        return [...]    # wing not in this list
+        return [...]  # wing not in this list
+
 
 # WRONG — wing returned in constraints; gets vectorized with WingAero
 class WingAero(Model):
     def setup(self, wing, state):
-        return [wing, ...]    # anti-pattern
+        return [wing, ...]  # anti-pattern
 ```
 
 ---
@@ -353,7 +357,7 @@ class Mission(Model):
     def setup(self, aircraft):
         self.aircraft = aircraft
 
-        with Vectorize(4):         # four flight segments — all share the same aircraft
+        with Vectorize(4):  # four flight segments — all share the same aircraft
             self.fs = FlightSegment(aircraft)
 
         Wburn = self.fs.aircraftp.Wburn
@@ -397,37 +401,39 @@ live in `Mission`.
 class BeamElement(Model):
     """Loads and displacements at one cross-section — the spatial analogue of FlightState."""
 
-    q  = Var("N/m", "distributed load")
-    V  = Var("N",   "internal shear")
-    M  = Var("N*m", "bending moment")
-    th = Var("-",   "slope")
-    w  = Var("m",   "deflection")
+    q = Var("N/m", "distributed load")
+    V = Var("N", "internal shear")
+    M = Var("N*m", "bending moment")
+    th = Var("-", "slope")
+    w = Var("m", "deflection")
 
     def setup(self):
-        pass   # no intra-element constraints; integration lives in the parent
+        pass  # no intra-element constraints; integration lives in the parent
 
 
 class Beam(Model):
     """Vectorizes BeamElement — the spatial analogue of Mission."""
 
     EI = Var("N*m^2", "bending stiffness")
-    L  = Var("m",     "beam length", value=5)
+    L = Var("m", "beam length", value=5)
 
     def setup(self, N=5):
         self.dx = self.L / N
 
         with Vectorize(N):
-            self.elem = BeamElement()    # N cross-sections; all vars become shape-(N,) arrays
+            self.elem = (
+                BeamElement()
+            )  # N cross-sections; all vars become shape-(N,) arrays
 
-        e = self.elem    # shorthand
+        e = self.elem  # shorthand
 
         return [
             # Trapezoidal integration: shear and moment from tip to root
-            e.V[:-1] >= e.V[1:]  + 0.5 * self.dx * (e.q[:-1]  + e.q[1:]),
-            e.M[:-1] >= e.M[1:]  + 0.5 * self.dx * (e.V[:-1]  + e.V[1:]),
+            e.V[:-1] >= e.V[1:] + 0.5 * self.dx * (e.q[:-1] + e.q[1:]),
+            e.M[:-1] >= e.M[1:] + 0.5 * self.dx * (e.V[:-1] + e.V[1:]),
             # Slope and deflection from root to tip
-            e.th[1:] >= e.th[:-1] + 0.5 * self.dx * (e.M[1:]  + e.M[:-1]) / self.EI,
-            e.w[1:]  >= e.w[:-1]  + 0.5 * self.dx * (e.th[1:] + e.th[:-1]),
+            e.th[1:] >= e.th[:-1] + 0.5 * self.dx * (e.M[1:] + e.M[:-1]) / self.EI,
+            e.w[1:] >= e.w[:-1] + 0.5 * self.dx * (e.th[1:] + e.th[:-1]),
         ]
 ```
 
@@ -559,15 +565,15 @@ The correct access pattern inside a Perf model is to use the Component's attribu
 
 ```python
 def setup(self, wing, state):
-    c = wing.c           # correct — uses wing's Variable object
-    S = wing.S           # correct
-    V = state.V          # correct
+    c = wing.c  # correct — uses wing's Variable object
+    S = wing.S  # correct
+    V = state.V  # correct
 ```
 
 Not:
 ```python
 def setup(self, wing, state):
-    c = wing["c"]        # fragile — string key lookup
+    c = wing["c"]  # fragile — string key lookup
 ```
 
 **Submodel attribute storage is the mechanism that makes attribute access work.** Every submodel
@@ -581,6 +587,7 @@ def setup(self, aircraft):
     self.perf = aircraft.perf(self.fs)
     self.wing = aircraft.wing
     return [self.fs, self.perf]
+
 
 # WRONG — wing only in a list; prevents mission.aircraft.wing.S access later
 def setup(self, aircraft):
@@ -602,7 +609,7 @@ caller will need to reference it, assign it to `self`.
 # BAD — modifies HorizontalTail for every future use in this process
 HorizontalTail.sparModel = BoxSparGP
 HorizontalTail.fillModel = None
-TailBoom.__bases__ = (BoxSparGP,)   # replaces base class globally!
+TailBoom.__bases__ = (BoxSparGP,)  # replaces base class globally!
 ```
 
 **Fix**: create explicit subclasses that override class attributes. Do not mutate shared classes.
@@ -613,9 +620,11 @@ class SolarHTail(HorizontalTail):
     fillModel = None
     skinModel = WingSecondStruct
 
+
 class SolarTailBoom(TailBoom):
     spar_model = BoxSparGP
     secondaryWeight = True
+
 
 # Pass the subclasses where needed:
 emp = Empennage(N=5, htail_cls=SolarHTail, tailboom_cls=SolarTailBoom)
@@ -630,7 +639,7 @@ choice. See `TailBoom.spar_model` and `Wing.sparModel` for examples of this patt
 # BAD — mutates WingSP globally even though this is called per-instance
 def setup(self, sp=False):
     if sp:
-        WingSP.fillModel = None   # global side effect
+        WingSP.fillModel = None  # global side effect
         self.wing = WingSP()
 ```
 
@@ -639,6 +648,7 @@ def setup(self, sp=False):
 ```python
 class _WingSP(WingSP):
     fillModel = None
+
 
 def setup(self, sp=False):
     if sp:
@@ -650,7 +660,7 @@ def setup(self, sp=False):
 ```python
 # BAD — changes Propeller's perf class globally by setting a class attribute
 class Propulsor(Model):
-    prop_flight_model = ActuatorProp   # class-level default
+    prop_flight_model = ActuatorProp  # class-level default
 
     def setup(self):
         self.prop = Propeller()
@@ -661,11 +671,13 @@ class Propulsor(Model):
 
 ```python
 class Propulsor(Model):
-    prop_flight_model = ActuatorProp   # class-level default
+    prop_flight_model = ActuatorProp  # class-level default
 
     def setup(self, prop_flight_model=None):
         self.prop = Propeller()
-        self.prop.flight_model = prop_flight_model or type(self).prop_flight_model  # instance only
+        self.prop.flight_model = (
+            prop_flight_model or type(self).prop_flight_model
+        )  # instance only
 ```
 
 Callers that need a different perf model pass it explicitly:
@@ -732,16 +744,19 @@ region.
 ```python
 # CORRECT — set at call site, after construction, using attribute access
 model = Mission()
-model.cost = model.aircraft.MTOW       # minimize takeoff weight
+model.cost = model.aircraft.MTOW  # minimize takeoff weight
 
 # Or for a different study objective using the same model:
-model.cost = model.fs.t_flight         # maximize endurance (invert: minimize 1/t)
+model.cost = model.fs.t_flight  # maximize endurance (invert: minimize 1/t)
+
 
 # WRONG — cost baked into setup(); objective cannot be changed without modifying the class
 class Mission(Model):
     def setup(self):
         ...
-        self.cost = self["MTOW"]       # anti-pattern: string subscript + hard-coded objective
+        self.cost = self[
+            "MTOW"
+        ]  # anti-pattern: string subscript + hard-coded objective
 ```
 
 **Anti-pattern note:** The API does not prevent setting cost inside `setup()`. It is a natural
@@ -794,14 +809,18 @@ def setup(self, sp=False):
     self.fuselage = Fuselage()
     ...
 
+
 # WRONG — latitude is a parameter, not a structural choice; set as substitution instead
 class Mission(Model):
-    def setup(self, latitude=45):                       # anti-pattern
+    def setup(self, latitude=45):  # anti-pattern
         self.lat = Variable("latitude", latitude, "deg", "latitude")
+
 
 # CORRECT replacement: latitude as a substitution at the call site
 model = Mission()
-model.substitutions[model.fs.latitude] = 45            # set at call site; can change without rebuild
+model.substitutions[model.fs.latitude] = (
+    45  # set at call site; can change without rebuild
+)
 ```
 
 ---
@@ -822,7 +841,7 @@ substitutions dict.
 ```python
 # CORRECT — Variable object as key; attribute access chain is exact and rename-safe
 self.emp.substitutions[self.emp.vtail.Vv] = 0.04
-model.substitutions[model.fs.altitude] = 10000        # ft
+model.substitutions[model.fs.altitude] = 10000  # ft
 
 # WRONG — string key; first-match lookup, breaks silently on rename
 model.substitutions["Vv"] = 0.04
@@ -853,22 +872,24 @@ a double-vectorization (an N×M tensor when only an N-vector was intended).
 class FlightSegment(Model):
     def setup(self, aircraft, N=5):
         with Vectorize(N):
-            self.fs = FlightState()                    # N FlightState instances
-            self.perf = aircraft.perf(self.fs)         # N Perf instances
+            self.fs = FlightState()  # N FlightState instances
+            self.perf = aircraft.perf(self.fs)  # N Perf instances
         return [self.fs, self.perf, ...]
+
 
 # CORRECT — leaf Component: NO Vectorize inside setup()
 class Wing(Model):
-    W = Var("lbf", "weight")    # scalar Var; becomes vector automatically when Wing is
-    S = Var("ft^2", "area")     # instantiated inside an external with Vectorize(N) block
+    W = Var("lbf", "weight")  # scalar Var; becomes vector automatically when Wing is
+    S = Var("ft^2", "area")  # instantiated inside an external with Vectorize(N) block
 
     def setup(self):
-        return [self.W >= self.S * self.rho]   # no Vectorize here; parent owns N
+        return [self.W >= self.S * self.rho]  # no Vectorize here; parent owns N
+
 
 # WRONG — leaf tries to own its own vectorization (double-vectorization risk)
 class Wing(Model):
     def setup(self, N=5):
-        with Vectorize(N):                     # anti-pattern for a leaf component
+        with Vectorize(N):  # anti-pattern for a leaf component
             self.W = Variable("W", "lbf", "weight")
 ```
 
@@ -932,7 +953,7 @@ and pass it to sub-model `setup()` methods as an argument:
 
 ```python
 class Powerplant(Model):
-    P_net = Var("W", "net output power")   # a Powerplant-level design variable
+    P_net = Var("W", "net output power")  # a Powerplant-level design variable
 
     def setup(self):
         self.alternator = Alternator()
@@ -1021,6 +1042,7 @@ class Box(Model):
         self.cost = 1 / (self.h * self.w * self.d)
         return [...]
 
+
 # No default() needed — inherits Model.default() which returns cls()
 ```
 
@@ -1039,7 +1061,7 @@ class AircraftMission(Model):
     @classmethod
     def default(cls):
         m = cls()
-        m.cost = m.aircraft.W_total   # attribute access
+        m.cost = m.aircraft.W_total  # attribute access
         m.substitutions[m.aircraft.W_payload] = 500  # Variable object key
         return m
 ```
@@ -1125,14 +1147,16 @@ Returns a list of direct child Model instances in `setup()` return order:
 ```python
 class Wing(Model):
     W = Var("lbf", "wing weight")
+
     def setup(self):
         self.spar = Spar()
         self.skin = Skin()
         return [self.W >= self.spar.W + self.skin.W, self.spar, self.skin]
 
+
 wing = Wing()
-wing.submodels           # [<Spar>, <Skin>]
-wing.submodels[0].W      # Spar's weight variable
+wing.submodels  # [<Spar>, <Skin>]
+wing.submodels[0].W  # Spar's weight variable
 ```
 
 Only Models explicitly returned from `setup()` as constraints appear in
@@ -1149,6 +1173,7 @@ class Vehicle(Model):
         self.wing = Wing()
         self.fuselage = Fuselage()
         ...
+
 
 v = Vehicle()
 for m in v.walk():
@@ -1186,8 +1211,8 @@ of interest.
 Resolves a dotted path to a `Variable` object:
 
 ```python
-mission.get_var("vehicle.wing.S")   # Wing's area variable
-mission.get_var("S")                # Mission's own S (not a child's)
+mission.get_var("vehicle.wing.S")  # Wing's area variable
+mission.get_var("S")  # Mission's own S (not a child's)
 ```
 
 The path uses the attribute names set in `setup()` (`self.vehicle = Vehicle()`).

--- a/gpkit/breakdowns.py
+++ b/gpkit/breakdowns.py
@@ -224,7 +224,9 @@ def get_breakdowns(basically_fixed_variables, solution):  # noqa: PLR0912, PLR09
     return breakdowns
 
 
-def get_fixity(basically_fixed, key, bd, solution, visited=set()):
+def get_fixity(basically_fixed, key, bd, solution, visited=None):
+    if visited is None:
+        visited = set()
     lt, gt, _ = bd[key][0]
     free_vks = get_free_vks(lt, solution).union(get_free_vks(gt, solution))
     for vk in free_vks:

--- a/gpkit/breakdowns.py
+++ b/gpkit/breakdowns.py
@@ -50,7 +50,7 @@ def is_power(key):
 
 def get_free_vks(posy, solution):
     "Returns all free vks of a given posynomial for a given solution"
-    return set(vk for vk in posy.vks if vk not in solution.constants)
+    return {vk for vk in posy.vks if vk not in solution.constants}
 
 
 def get_model_breakdown(solution):
@@ -395,7 +395,7 @@ def crawl(  # noqa: PLR0912, PLR0913, PLR0915, PLR0917
             )  # ~5% of total last check # TODO: remove
             # TODO: changing to str(vk) above does some odd stuff, why?
             if best_vks:
-                interesting_vks = set([best_vks[0]])
+                interesting_vks = {best_vks[0]}
         boring_vks = mon.vks - interesting_vks
 
         subkey = None

--- a/gpkit/breakdowns.py
+++ b/gpkit/breakdowns.py
@@ -243,7 +243,7 @@ def get_fixity(basically_fixed, key, bd, solution, visited=set()):
 
 
 # @profile  # ~84% of total last check # TODO: remove
-def crawl(  # noqa: PLR0912, PLR0913, PLR0915
+def crawl(  # noqa: PLR0912, PLR0913, PLR0915, PLR0917
     basically_fixed_variables,
     key,
     bd,
@@ -543,7 +543,7 @@ def get_spanstr(legend, length, label, leftwards, solution):  # noqa: ARG001
         return "┃" * (longside + 1) + shortname + "┃" * (shortside + 1)
 
 
-def discretize(tree, extent, solution, collapse, depth=0, justsplit=False):  # noqa: PLR0912, PLR0913, PLR0915
+def discretize(tree, extent, solution, collapse, depth=0, justsplit=False):  # noqa: PLR0912, PLR0913, PLR0915, PLR0917
     # TODO: add vertical simplification?
     key, val, branches = tree
     if collapse:  # collapse Transforms with power 1
@@ -725,7 +725,7 @@ def prune(tree, solution, maxlength, length=-1, prefix=""):
     )
 
 
-def simplify(tree, solution, extent, maxdepth, maxlength, collapse):  # noqa: PLR0913
+def simplify(tree, solution, extent, maxdepth, maxlength, collapse):  # noqa: PLR0913, PLR0917
     "Discretize, prune, and layer a tree to prepare for printing"
     subtree = discretize(tree, extent, solution, collapse)
     if collapse and maxlength:
@@ -956,7 +956,7 @@ def get_valstr(key, solution, into="%s"):
     return into % (valuestr + unitstr)
 
 
-class Breakdowns(object):
+class Breakdowns:
     def __init__(self, sol):
         self.sol = sol
         self.lineage_map = get_lineage_map(sol)
@@ -978,7 +978,7 @@ class Breakdowns(object):
         self.bd = get_breakdowns(self.basically_fixed_variables, self.sol)
 
     def trace(self, key, *, permissivity=2):
-        print("")  # a little padding to start
+        print()  # a little padding to start
         with lineage_display_context(self.lineage_map):
             self.get_tree(key, permissivity=permissivity, verbosity=1)
 

--- a/gpkit/breakdowns.py
+++ b/gpkit/breakdowns.py
@@ -587,7 +587,7 @@ def discretize(tree, extent, solution, collapse, depth=0, justsplit=False):  # n
         _, _, branches, values = bvs
         branches = list(branches)
         values = list(values)
-    extents = [int(round(scale * v)) for v in values]
+    extents = [round(scale * v) for v in values]
     surplus = extent - sum(extents)
     for i, b in enumerate(branches):
         if isinstance(b.key, Transform):
@@ -616,7 +616,7 @@ def discretize(tree, extent, solution, collapse, depth=0, justsplit=False):  # n
                 miscval += v
         misckeys = tuple(k for _, _, k in sorted(miscvkeys))
         branches.append(Tree(misckeys, miscval, []))
-        extents.append(int(round(scale * miscval)))
+        extents.append(round(scale * miscval))
     if surplus:
         sign = int(np.sign(surplus))
         bump_priority = sorted(

--- a/gpkit/breakdowns.py
+++ b/gpkit/breakdowns.py
@@ -567,9 +567,8 @@ def discretize(tree, extent, solution, collapse, depth=0, justsplit=False):  # n
     bkey_indexs = {}
     for i, b in enumerate(branches):
         k = get_keystr(b.key, solution)
-        if isinstance(b.key, Transform):
-            if len(b.branches) == 1:
-                k = get_keystr(b.branches[0].key, solution)
+        if isinstance(b.key, Transform) and len(b.branches) == 1:
+            k = get_keystr(b.branches[0].key, solution)
         if k in bkey_indexs:
             values[bkey_indexs[k]] += values[i]
             values[i] = None

--- a/gpkit/budgets.py
+++ b/gpkit/budgets.py
@@ -282,17 +282,21 @@ class Budget:
             lines = [
                 "| Component | Nominal | Growth | Total | Units | Fraction |",
                 "| --- | ---: | ---: | ---: | :--- | ---: |",
-                f"| **{top_label}** | **{self.cbe_total:.4g}** "
-                f"| **{self.ga_total:.4g}** | **{self.total:.4g}** "
-                f"| **[{self.units}]** | **100.0%** |",
+                (
+                    f"| **{top_label}** | **{self.cbe_total:.4g}** "
+                    f"| **{self.ga_total:.4g}** | **{self.total:.4g}** "
+                    f"| **[{self.units}]** | **100.0%** |"
+                ),
             ]
             _collect_md_rows(self.children, lines, depth=0, show_growth=True)
             return "\n".join(lines)
         lines = [
             "| Component | Value | Units | Fraction |",
             "| --- | ---: | :--- | ---: |",
-            f"| **{top_label}** | **{self.total:.4g}** "
-            f"| **[{self.units}]** | **100.0%** |",
+            (
+                f"| **{top_label}** | **{self.total:.4g}** "
+                f"| **[{self.units}]** | **100.0%** |"
+            ),
         ]
         _collect_md_rows(self.children, lines, depth=0)
         return "\n".join(lines)
@@ -376,8 +380,10 @@ def _render_growth_text(budget, top_label, header):
     lines = [
         header,
         "-" * len(header),
-        f"  {' ' * w['lbl']}  {'Nominal':>{w['cbe']}}  {'Growth':>{w['ga']}}  "
-        f"{'Total':>{w['tot']}}  {'':>{w['unt']}}  {'':>{w['pct']}}",
+        (
+            f"  {' ' * w['lbl']}  {'Nominal':>{w['cbe']}}  {'Growth':>{w['ga']}}  "
+            f"{'Total':>{w['tot']}}  {'':>{w['unt']}}  {'':>{w['pct']}}"
+        ),
     ]
     for row in rows:
         lines.append(_format_growth_row(row, w))

--- a/gpkit/budgets.py
+++ b/gpkit/budgets.py
@@ -16,7 +16,6 @@ Usage example::
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
 
 from .ast_nodes import ExprNode, VarNode
 from .constraints.set import flatiter
@@ -216,7 +215,7 @@ class BudgetNode:
     """
 
     label: str
-    vk: Optional[VarKey]
+    vk: VarKey | None
     value: float
     fraction: float
     slack: float
@@ -486,8 +485,8 @@ class _TermData:
     exp: object
     phys_coeff: float
     term_val: float
-    ast_label: Optional[str]
-    is_var_node: Optional[bool] = None  # True iff AST term is a bare VarNode
+    ast_label: str | None
+    is_var_node: bool | None = None  # True iff AST term is a bare VarNode
     term_qty: object = None  # pint Quantity from solution[mon], or None on failure
 
 

--- a/gpkit/constraints/costed.py
+++ b/gpkit/constraints/costed.py
@@ -51,7 +51,7 @@ class CostedConstraintSet(ConstraintSet):
     def __init__(self, cost, constraints, substitutions=None):
         self.cost = maybe_flatten(cost)
         if isinstance(self.cost, np.ndarray):  # if it's still a vector
-            raise ValueError("Cost must be scalar, not the vector {cost}.")
+            raise TypeError(f"Cost must be scalar, not the vector {self.cost}.")
         subs = {k: k.value for k in self.cost.vks if k.value is not None}
         if substitutions:
             subs.update(substitutions)

--- a/gpkit/examples/relaxation.py
+++ b/gpkit/examples/relaxation.py
@@ -15,7 +15,7 @@ m = Model(x, [x <= x_max, x >= x_min])
 print("Original model")
 print("==============")
 print(m)
-print("")
+print()
 # m.solve()  # raises a RuntimeWarning!
 
 print("With constraints relaxed equally")
@@ -28,7 +28,7 @@ print(mr1)
 print(mr1.solve(verbosity=0).table())  # solves with an x of 1.414
 
 Breakdowns(mr1.solution).trace("cost")
-print("")
+print()
 
 print("With constraints relaxed individually")
 print("=====================================")
@@ -42,7 +42,7 @@ mr2 = Model(
 )
 print(mr2)
 print(mr2.solve(verbosity=0).table())  # solves with an x of 1.0
-print("")
+print()
 
 print("With constants relaxed individually")
 print("===================================")
@@ -56,4 +56,4 @@ mr3 = Model(
 )
 print(mr3)
 print(mr3.solve(verbosity=0).table())  # brings x_min down to 1.0
-print("")
+print()

--- a/gpkit/examples/uav.py
+++ b/gpkit/examples/uav.py
@@ -356,9 +356,11 @@ class UAV(Model):
     """
 
     references: ClassVar = [
-        'W. Hoburg, "Geometric Programming for Aircraft Design Optimization,"'
-        " PhD thesis, MIT/UC Berkeley, 2013."
-        " https://people.eecs.berkeley.edu/~pabbeel/papers/2013_Hoburg-phdthesis.pdf"
+        (
+            'W. Hoburg, "Geometric Programming for Aircraft Design Optimization,"'
+            " PhD thesis, MIT/UC Berkeley, 2013."
+            " https://people.eecs.berkeley.edu/~pabbeel/papers/2013_Hoburg-phdthesis.pdf"
+        )
     ]
 
     def setup(self):

--- a/gpkit/examples/uav.py
+++ b/gpkit/examples/uav.py
@@ -10,6 +10,7 @@ https://people.eecs.berkeley.edu/~pabbeel/papers/2013_Hoburg-phdthesis.pdf
 """
 
 import math
+from typing import ClassVar
 
 from gpkit import Model, Var, Variable, pi, units
 
@@ -354,7 +355,7 @@ class UAV(Model):
     Submodels are accessed via attributes (aircraft.wing, mission.outbound_leg).
     """
 
-    references = [
+    references: ClassVar = [
         'W. Hoburg, "Geometric Programming for Aircraft Design Optimization,"'
         " PhD thesis, MIT/UC Berkeley, 2013."
         " https://people.eecs.berkeley.edu/~pabbeel/papers/2013_Hoburg-phdthesis.pdf"

--- a/gpkit/interactive/sankey.py
+++ b/gpkit/interactive/sankey.py
@@ -169,7 +169,7 @@ class Sankey:
         showconstraints=True,
     ):
         "creates links and an ipython widget to show them"
-        margins = dict(top=top, bottom=bottom, left=left, right=right)
+        margins = {"top": top, "bottom": bottom, "left": left, "right": right}
         self.minsenss = minsenss
         self.maxlinks = maxlinks
         self.showconstraints = showconstraints

--- a/gpkit/interactive/sankey.py
+++ b/gpkit/interactive/sankey.py
@@ -251,7 +251,9 @@ class Sankey:
         culldepth = max(node.count(".") for node in self.nodes) - 1
         mindepth = 1 if not top_node else top_node.count(".") + 1
         while len(links) > self.maxlinks and culldepth > mindepth:
-            self.filter(links, lambda s, _t, _v: culldepth > s.count("."))
+            # filter() calls this synchronously, so culldepth is read at its
+            # current value each iteration -- no late-binding closure issue.
+            self.filter(links, lambda s, _t, _v: culldepth > s.count("."))  # noqa: B023
             culldepth -= 1
         # ...is a constraint and we still have too many links
         self.filter(links, lambda s, _t, _v: "constraint" not in self.nodes[s])

--- a/gpkit/nomials/constraints.py
+++ b/gpkit/nomials/constraints.py
@@ -29,7 +29,7 @@ class SingleEquationConstraint(ReprMixin):
             oper = self.unicode_opers[self.oper]
         else:
             oper = self.oper
-        return " ".join((leftstr, oper, rightstr))
+        return f"{leftstr} {oper} {rightstr}"
 
     def to_ir(self):
         "Serialize the common constraint structure to an IR dict."

--- a/gpkit/nomials/constraints.py
+++ b/gpkit/nomials/constraints.py
@@ -1,6 +1,7 @@
 "Base classes for nomial-layer constraints."
 
 from operator import eq, ge, le
+from typing import ClassVar
 
 from ..util.repr_conventions import UNICODE_EXPONENTS, ReprMixin
 from ..util.small_scripts import try_str_without
@@ -9,9 +10,9 @@ from ..util.small_scripts import try_str_without
 class SingleEquationConstraint(ReprMixin):
     "Constraint expressible in a single equation."
 
-    latex_opers = {"<=": "\\leq", ">=": "\\geq", "=": "="}
-    unicode_opers = {"<=": "≤", ">=": "≥", "=": "="}
-    func_opers = {"<=": le, ">=": ge, "=": eq}
+    latex_opers: ClassVar = {"<=": "\\leq", ">=": "\\geq", "=": "="}
+    unicode_opers: ClassVar = {"<=": "≤", ">=": "≥", "=": "="}
+    func_opers: ClassVar = {"<=": le, ">=": ge, "=": eq}
 
     def __init__(self, left, oper, right):
         self.left, self.oper, self.right = left, oper, right

--- a/gpkit/nomials/data.py
+++ b/gpkit/nomials/data.py
@@ -63,6 +63,4 @@ class NomialData(ReprMixin):
             return NotImplemented
         if self.hmap != other.hmap:
             return False
-        if self.units != other.units:
-            return False
-        return True
+        return self.units == other.units

--- a/gpkit/nomials/map.py
+++ b/gpkit/nomials/map.py
@@ -56,7 +56,7 @@ class NomialMap(HashVector):
         """
         hmap = cls()
         for term in ir_dict["terms"]:
-            if "exps" in term and term["exps"]:
+            if term.get("exps"):
                 exp = HashVector(
                     {var_registry[ref]: x for ref, x in term["exps"].items()}
                 )
@@ -209,7 +209,7 @@ class NomialMap(HashVector):
         return pmap
 
 
-def subinplace(cp, exp, o_exp, vk, cval, squished):  # noqa: PLR0913
+def subinplace(cp, exp, o_exp, vk, cval, squished):  # noqa: PLR0913, PLR0917
     "Modifies cp by substituing cval/expval for vk in exp"
     x = exp[vk]
     powval = float(cval) ** x if cval != 0 or x >= 0 else np.sign(cval) * np.inf

--- a/gpkit/nomials/math.py
+++ b/gpkit/nomials/math.py
@@ -1,6 +1,7 @@
 """Signomial, Posynomial, and Monomial classes"""
 
 from collections import defaultdict
+from typing import ClassVar
 
 import numpy as np
 
@@ -391,7 +392,8 @@ class ScalarSingleEquationConstraint(SingleEquationConstraint):
     "A SingleEquationConstraint with scalar left and right sides."
 
     generated_by = v_ss = parent = None
-    bounded = meq_bounded = {}
+    bounded: ClassVar = {}
+    meq_bounded: ClassVar = {}
 
     def __init__(self, left, oper, right):
         lr = [left, right]

--- a/gpkit/nomials/substitution.py
+++ b/gpkit/nomials/substitution.py
@@ -7,7 +7,7 @@ from ..varmap import VarSet
 
 def is_linked(val):
     "Return True if val is a linked (callable-computed) substitution value."
-    return hasattr(val, "__call__") and not hasattr(val, "key")
+    return callable(val) and not hasattr(val, "key")
 
 
 def parse_subs(varkeys, substitutions):

--- a/gpkit/nomials/variables.py
+++ b/gpkit/nomials/variables.py
@@ -176,20 +176,19 @@ class ArrayVariable(NomialArray):
             descr["name"] = "\\fbox{%s}" % VarKey.unique_id()
 
         values = descr.pop("value", None)
-        if values is not None:
-            if not callable(values):
-                if Vectorize.vectorization:
-                    if not hasattr(values, "shape"):
-                        values = np.full(shape, values, np.float64)
-                    else:
-                        values = np.broadcast_to(values, reversed(shape)).T
-                elif not hasattr(values, "shape"):
-                    values = np.array(values)
-                if values.shape != shape:
-                    raise ValueError(
-                        f"value's shape {values.shape} is different from the"
-                        f" vector's {shape}."
-                    )
+        if values is not None and not callable(values):
+            if Vectorize.vectorization:
+                if not hasattr(values, "shape"):
+                    values = np.full(shape, values, np.float64)
+                else:
+                    values = np.broadcast_to(values, reversed(shape)).T
+            elif not hasattr(values, "shape"):
+                values = np.array(values)
+            if values.shape != shape:
+                raise ValueError(
+                    f"value's shape {values.shape} is different from the"
+                    f" vector's {shape}."
+                )
 
         veckeydescr = descr.copy()
         addmodelstodescr(veckeydescr)

--- a/gpkit/nomials/variables.py
+++ b/gpkit/nomials/variables.py
@@ -148,7 +148,7 @@ class ArrayVariable(NomialArray):
     where $name is the vector's name and i is the VarKey's index.
     """
 
-    def __new__(cls, shape, *args, **descr):  # noqa: PLR0912, PLR0915
+    def __new__(cls, shape, *args, **descr):  # noqa: PLR0912
         if "idx" in descr:
             raise ValueError("the description field 'idx' is reserved")
 
@@ -165,9 +165,7 @@ class ArrayVariable(NomialArray):
                 isinstance(arg, (Numbers, Iterable))
                 and not isinstance(arg, Strings)
                 and "value" not in descr
-            ):
-                descr["value"] = arg
-            elif hasattr(arg, "__call__"):
+            ) or hasattr(arg, "__call__"):
                 descr["value"] = arg
             elif isinstance(arg, Strings) and "units" not in descr:
                 descr["units"] = arg

--- a/gpkit/nomials/variables.py
+++ b/gpkit/nomials/variables.py
@@ -57,7 +57,7 @@ class Variable(Monomial):
                 if isinstance(arg, Strings) and "name" not in descr:
                     descr["name"] = arg
                 elif (
-                    isinstance(arg, Numbers) or hasattr(arg, "__call__")
+                    isinstance(arg, Numbers) or callable(arg)
                 ) and "value" not in descr:
                     descr["value"] = arg
                 elif isinstance(arg, Iterable) and not isinstance(arg, Strings):
@@ -165,7 +165,7 @@ class ArrayVariable(NomialArray):
                 isinstance(arg, (Numbers, Iterable))
                 and not isinstance(arg, Strings)
                 and "value" not in descr
-            ) or hasattr(arg, "__call__"):
+            ) or callable(arg):
                 descr["value"] = arg
             elif isinstance(arg, Strings) and "units" not in descr:
                 descr["units"] = arg
@@ -177,7 +177,7 @@ class ArrayVariable(NomialArray):
 
         values = descr.pop("value", None)
         if values is not None:
-            if not hasattr(values, "__call__"):
+            if not callable(values):
                 if Vectorize.vectorization:
                     if not hasattr(values, "shape"):
                         values = np.full(shape, values, np.float64)
@@ -205,7 +205,7 @@ class ArrayVariable(NomialArray):
             it.iternext()
             descr["idx"] = i
             if values is not None:
-                if hasattr(values, "__call__"):  # a vector function
+                if callable(values):  # a vector function
                     descr["value"] = veclinkedfn(values, i)
                 else:
                     descr["value"] = values[i]

--- a/gpkit/printing.py
+++ b/gpkit/printing.py
@@ -374,7 +374,7 @@ class SolutionSection(Constants):
         sizes = {np.asarray(v[0]).size for _, v in vec_items if np.shape(v[0])}
         if len(sizes) != 1:
             return None
-        n = min(list(sizes)[0], self.options.vecn)
+        n = min(next(iter(sizes)), self.options.vecn)
         p = self.options.precision
         widths = [0] * n
         for _, (val, sens) in vec_items:

--- a/gpkit/printing.py
+++ b/gpkit/printing.py
@@ -1,8 +1,9 @@
 "printing functionality for gpkit objects"
 
 from collections import Counter, defaultdict
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, replace
-from typing import Any, Callable, Iterable, List, Sequence, Tuple
+from typing import Any
 
 import numpy as np
 
@@ -85,7 +86,7 @@ class SectionSpec:
                 return self.__class__(options=newopt)
         return self
 
-    def format(self, ctx) -> List[str]:
+    def format(self, ctx) -> list[str]:
         "Output this section's lines given a solution or solution context"
         items = [item for item in self.items_from(ctx) if self._passes_filter(item)]
         if self.group_by_model:
@@ -736,7 +737,7 @@ class DiffContext:
 
 def table(
     obj: Any,  # Solution or SolutionSequence
-    tables: Tuple[str, ...] = (
+    tables: tuple[str, ...] = (
         "sweeps",
         "cost",
         "warnings",

--- a/gpkit/printing.py
+++ b/gpkit/printing.py
@@ -79,7 +79,7 @@ class SectionSpec:
     def _auto_vecwidth_rowspec(self, items):
         "Return a copy of this with vec_width set automatically for items"
         if self.align_vecs and self.options.vec_width is None:
-            lengths = set(np.shape(v) for _, v in items if np.shape(v))
+            lengths = {np.shape(v) for _, v in items if np.shape(v)}
             if len(lengths) == 1:
                 width = self._max_val_width(items)
                 newopt = replace(self.options, vec_width=width)
@@ -793,7 +793,7 @@ def _format_aligned_columns(
     """
     if not rows:
         return []
-    (ncols,) = set(len(r) for r in rows) or (0,)
+    (ncols,) = {len(r) for r in rows} or (0,)
     if col_alignments is None:
         col_alignments = "<" * ncols
     assert len(col_alignments) == ncols

--- a/gpkit/programs/gp.py
+++ b/gpkit/programs/gp.py
@@ -3,9 +3,9 @@
 import sys
 import warnings as pywarnings
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from time import time
-from typing import Sequence
 
 import numpy as np
 

--- a/gpkit/programs/gp.py
+++ b/gpkit/programs/gp.py
@@ -476,7 +476,7 @@ class GeometricProgram:
             m_senss[lineagestr(c)] += abs(c_senss)
 
         # Handle linked sensitivities
-        for v in list(v for v in gpv_ss if self.linked_derivs.get(v)):
+        for v in [v for v in gpv_ss if self.linked_derivs.get(v)]:
             dlogcost_dlogv = gpv_ss.pop(v)
             dlogcost_dlogabsv = absv_ss.pop(v)
             val = np.array(self.substitutions[v])
@@ -575,7 +575,7 @@ class GeometricProgram:
         Pops each intermediate VarKey that has linked derivatives and
         accumulates its sensitivity into the base constants.
         """
-        for v in list(v for v in sens_dict if self.linked_derivs.get(v)):
+        for v in [v for v in sens_dict if self.linked_derivs.get(v)]:
             dsens_dlogv = sens_dict.pop(v)
             val = np.array(self.substitutions[v])
             for c, dv_dc in self.linked_derivs[v].items():

--- a/gpkit/programs/gp.py
+++ b/gpkit/programs/gp.py
@@ -763,12 +763,14 @@ class GeometricProgram:
         if self.integersolve:
             warnings["No Dual Solution"] = [
                 (
-                    "This model has the discretized choice variables"
-                    f" {sorted(self.choicevaridxs.keys())} and hence no dual"
-                    " solution. You can fix those variables to their optimal"
-                    " values and get sensitivities to the resulting"
-                    " continuous problem by updating your model's"
-                    " substitions with `sol['choicevariables']`.",
+                    (
+                        "This model has the discretized choice variables"
+                        f" {sorted(self.choicevaridxs.keys())} and hence no dual"
+                        " solution. You can fix those variables to their optimal"
+                        " values and get sensitivities to the resulting"
+                        " continuous problem by updating your model's"
+                        " substitions with `sol['choicevariables']`."
+                    ),
                     self.choicevaridxs,
                 )
             ]
@@ -776,10 +778,12 @@ class GeometricProgram:
         if self.choicevaridxs:
             warnings["Freed Choice Variables"] = [
                 (
-                    "This model has the discretized choice variables"
-                    f" {sorted(self.choicevaridxs.keys())}, but since the "
-                    f"'{solver_out.meta['solver']}' solver doesn't support "
-                    "discretization they were treated as continuous variables.",
+                    (
+                        "This model has the discretized choice variables"
+                        f" {sorted(self.choicevaridxs.keys())}, but since the "
+                        f"'{solver_out.meta['solver']}' solver doesn't support "
+                        "discretization they were treated as continuous variables."
+                    ),
                     self.choicevaridxs,
                 )
             ]  # TODO: choicevaridxs seems unnecessary

--- a/gpkit/programs/gp.py
+++ b/gpkit/programs/gp.py
@@ -58,7 +58,7 @@ def _get_solver(solver, kwargs):
         optimize = optimize_generator(**kwargs)
     elif solver == "mosek_conif":
         from ..solvers.mosek_conif import optimize  # noqa: PLC0415
-    elif hasattr(solver, "__call__"):
+    elif callable(solver):
         solver, optimize = solver.__name__, solver
     else:
         raise ValueError(f"Unknown solver '{solver}'.")

--- a/gpkit/programs/gp.py
+++ b/gpkit/programs/gp.py
@@ -488,11 +488,10 @@ class GeometricProgram:
                     absv_ss[c] = absv_ss.get(c, 0) + abs(
                         dlogcost_dlogabsv * dlogv_dlogc
                     )
-                if v in cost_senss:
-                    if c in self.cost.vks:  # TODO: seems unnecessary
-                        dlogcost_dlogv = cost_senss.pop(v)
-                        before = cost_senss.get(c, 0)
-                        cost_senss[c] = before + dlogcost_dlogv * dlogv_dlogc
+                if v in cost_senss and c in self.cost.vks:  # TODO: seems unnecessary
+                    dlogcost_dlogv = cost_senss.pop(v)
+                    before = cost_senss.get(c, 0)
+                    cost_senss[c] = before + dlogcost_dlogv * dlogv_dlogc
 
         return cost_senss, gpv_ss, absv_ss, m_senss, constraint_senss
 

--- a/gpkit/report.py
+++ b/gpkit/report.py
@@ -619,7 +619,7 @@ def _text_cgroup_lines(constraint_groups: list, pad: str, lineage_map: dict) -> 
     return lines
 
 
-def _text_constraint_rows(constraints: list, lineage_map: dict = None) -> list:
+def _text_constraint_rows(constraints: list, lineage_map: dict | None = None) -> list:
     """Build aligned rows for a constraint group in text output.
 
     lineage_map is a _name_collision_varkeys dict; activating it makes

--- a/gpkit/report.py
+++ b/gpkit/report.py
@@ -6,7 +6,7 @@ functions of the IR.
 """
 
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Tuple
+from typing import Any
 
 from .constraints.tight import Tight
 from .model import Model as _Model
@@ -24,7 +24,7 @@ class VarEntry:
     name: str  # display name (from VarKey.name)
     latex: str  # LaTeX rendering (from VarKey.latex())
     value: Any  # float | ndarray | None — never a pint Quantity
-    sensitivity: Optional[float]  # shadow price from solution, or None
+    sensitivity: float | None  # shadow price from solution, or None
     units: str  # unit string
     label: str  # human label (from VarKey.label or "")
     source: str = ""  # lineagestr() for cross-model referenced vars; "" for local
@@ -80,9 +80,7 @@ class ReportSection:
     objective_str: str = ""  # text representation of cost expression; "" if constant
     objective_latex: str = ""  # LaTeX representation of cost expression
     objective_label: str = ""  # variable label when expr is a single variable; else ""
-    objective_value: Optional[float] = (
-        None  # magnitude of attained cost; None if unsolved
-    )
+    objective_value: float | None = None  # magnitude of attained cost; None if unsolved
     objective_units: str = ""  # unit string for the cost expression
     objective_direction: str = "minimize"  # "minimize" or "maximize"
 
@@ -149,7 +147,7 @@ def _serialize_value(val: Any) -> Any:
         return str(val)
 
 
-def _value_units(vk, varmap: VarMap) -> Tuple[Any, str]:
+def _value_units(vk, varmap: VarMap) -> tuple[Any, str]:
     """Get (magnitude, unit_str) for vk from varmap.
 
     Both values come from the same pint Quantity returned by varmap.quantity(),
@@ -195,7 +193,7 @@ def _render_constraint(c) -> str:
 # ── Core builder helpers ──────────────────────────────────────────────────────
 
 
-def _collect_constraint_varkeys(constraint_groups: List[CGroup]) -> set:
+def _collect_constraint_varkeys(constraint_groups: list[CGroup]) -> set:
     """Collect all VarKeys appearing in local constraint groups.
 
     Note: ConstraintSet.constrained_varkeys() (set.py) does the same concept
@@ -244,7 +242,7 @@ def _is_free_vk(display_vk, solution, model) -> bool:
 
 def _build_split_var_entries(
     model, solution, extra_vks=None
-) -> Tuple[List[VarEntry], List[VarEntry]]:
+) -> tuple[list[VarEntry], list[VarEntry]]:
     """Build (free_entries, fixed_entries) from model.unique_varkeys.
 
     free_entries  — Optimized Variables: solved by the optimizer (no sens shown).
@@ -269,8 +267,8 @@ def _build_split_var_entries(
 
     lineage_map = model._name_collision_varkeys
     excluded = {":MAGIC:" + model.lineagestr()} if model.lineagestr() else set()
-    free_entries: List[VarEntry] = []
-    fixed_entries: List[VarEntry] = []
+    free_entries: list[VarEntry] = []
+    fixed_entries: list[VarEntry] = []
     seen_veckeys: set = set()
 
     with lineage_display_context(lineage_map):
@@ -335,7 +333,7 @@ def _collect_leaf_constraints(container) -> list:
     return result
 
 
-def _build_constraint_groups(model) -> List[CGroup]:
+def _build_constraint_groups(model) -> list[CGroup]:
     """Build CGroup list from model.cgroups or a single unnamed group.
 
     CGroup.constraints holds only leaf (single-equation) constraints;

--- a/gpkit/solutions.py
+++ b/gpkit/solutions.py
@@ -3,8 +3,8 @@
 import json
 import pickle
 import weakref
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import List, Sequence
 
 from . import printing
 from .breakdowns import bdtable_gen
@@ -281,7 +281,7 @@ class Solution:
         return bdtable_gen("model sensitivities")(self, set())
 
 
-class SolutionSequence(List[Solution]):
+class SolutionSequence(list[Solution]):
     """
     Ordered collection of Solution objects all sharing same underlying model.
     """

--- a/gpkit/solutions.py
+++ b/gpkit/solutions.py
@@ -105,8 +105,10 @@ class MarginSolution:
         """
         u = f" {self.units}" if self.units else ""
         lines = [
-            f"\n{self.name}: {self.value:.4g}{u}"
-            f"  (plus={self.plus_value:.4g}{u}, minus={self.minus_value:.4g}{u})",
+            (
+                f"\n{self.name}: {self.value:.4g}{u}"
+                f"  (plus={self.plus_value:.4g}{u}, minus={self.minus_value:.4g}{u})"
+            ),
         ]
         if not self.sensitivities:
             return "\n".join(lines)

--- a/gpkit/solvers/mosek_cli.py
+++ b/gpkit/solvers/mosek_cli.py
@@ -158,8 +158,7 @@ def write_output_file(filename, c, A, p_idxs):
     with open(filename, "w", encoding="utf-8") as f:
         numcon = p_idxs[-1]
         numter, numvar = map(int, A.shape)
-        for n in [numcon, numvar, numter]:
-            f.write(f"{n}\n")
+        f.writelines(f"{n}\n" for n in [numcon, numvar, numter])
 
         f.write("\n*c\n")
         f.writelines([f"{x:.20e}\n" for x in c])

--- a/gpkit/solvers/mosek_cli.py
+++ b/gpkit/solvers/mosek_cli.py
@@ -59,9 +59,11 @@ def optimize_generator(path=None, **_):
     if tmpdir:
         path = tempfile.mkdtemp()
     filename = path + os.sep + "gpkit_mosek"
-    if "mosek_bin_dir" in settings:
-        if settings["mosek_bin_dir"] not in os.environ["PATH"]:
-            os.environ["PATH"] += ":" + settings["mosek_bin_dir"]
+    if (
+        "mosek_bin_dir" in settings
+        and settings["mosek_bin_dir"] not in os.environ["PATH"]
+    ):
+        os.environ["PATH"] += ":" + settings["mosek_bin_dir"]
 
     def optimize(prob, **_):
         """Interface to the MOSEK "mskexpopt" command line solver

--- a/gpkit/solvers/mosek_conif.py
+++ b/gpkit/solvers/mosek_conif.py
@@ -257,7 +257,7 @@ def optimize(prob, **kwargs):  # noqa: PLR0912, PLR0915
             mosek.rescode.err_license_expired,
         ]:
             raise InvalidLicense() from e
-        raise e
+        raise
 
     if verbose:
         task.solutionsummary(mosek.streamtype.msg)

--- a/gpkit/tests/conftest.py
+++ b/gpkit/tests/conftest.py
@@ -131,7 +131,7 @@ def example(request, solver):
     """
     # Extract example name from test function (use originalname to strip params)
     test_name = request.node.originalname
-    example_name = test_name[5:] if test_name.startswith("test_") else test_name
+    example_name = test_name.removeprefix("test_")
 
     with NewDefaultSolver(solver):
         mod = _import_example(example_name)

--- a/gpkit/tests/test_constraints.py
+++ b/gpkit/tests/test_constraints.py
@@ -20,7 +20,7 @@ from gpkit.constraints.relax import (
     ConstraintsRelaxedEqually,
 )
 from gpkit.constraints.tight import Tight
-from gpkit.exceptions import InvalidGPConstraint, PrimalInfeasible
+from gpkit.exceptions import Infeasible, InvalidGPConstraint, PrimalInfeasible
 from gpkit.nomials import MonomialEquality, PosynomialInequality, SignomialInequality
 from gpkit.nomials.substitution import parse_subs
 from gpkit.units import DimensionalityError
@@ -290,7 +290,7 @@ class TestMonomialEquality:
         d1 = Variable("d1", 2)
         d2 = Variable("d2", 3)
         m = Model(y, [x == d1, x == d2, y >= x])
-        with pytest.raises(Exception):
+        with pytest.raises(Infeasible):
             m.solve(verbosity=0)
 
     def test_duplicate_constraint_detection(self):

--- a/gpkit/tests/test_constraints.py
+++ b/gpkit/tests/test_constraints.py
@@ -205,7 +205,7 @@ class TestCostedConstraint:
 
     def test_vector_cost(self):
         x = VectorVariable(2, "x")
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             CostedConstraintSet(x, [])
         _ = CostedConstraintSet(np.array(x[0]), [])
 

--- a/gpkit/tests/test_model.py
+++ b/gpkit/tests/test_model.py
@@ -509,9 +509,9 @@ class TestSP:
 
         sys.stdout = old_stdout
         assert stringout.getvalue() == (
-            f"Warning: SignomialConstraint {str(m1[0])} became the "
+            f"Warning: SignomialConstraint {m1[0]!s} became the "
             "tautological constraint 0 <= 3 + x after substitution.\n"
-            f"Warning: SignomialConstraint {str(m1[0])} became the "
+            f"Warning: SignomialConstraint {m1[0]!s} became the "
             "tautological constraint 0 <= 3 + x after substitution.\n"
         )
 
@@ -534,9 +534,9 @@ class TestSP:
 
         sys.stdout = old_stdout
         assert stringout.getvalue() == (
-            f"Warning: SignomialConstraint {str(m1[0])} became the "
+            f"Warning: SignomialConstraint {m1[0]!s} became the "
             "tautological constraint 0 <= 1 + x after substitution.\n"
-            f"Warning: SignomialConstraint {str(m2[0])} became the "
+            f"Warning: SignomialConstraint {m2[0]!s} became the "
             "tautological constraint 0 <= 1 + x after substitution.\n"
         )
 
@@ -700,9 +700,8 @@ class TestSP:
         c = Variable("c")
         y = Variable("y")
         m = Model(x, [y >= 1 + c * x, y <= 0.5], {c: -1})
-        with pytest.raises(InvalidGPConstraint):
-            with SignomialsEnabled():
-                m.gp()
+        with pytest.raises(InvalidGPConstraint), SignomialsEnabled():
+            m.gp()
         with pytest.raises(UnnecessarySGP):
             m.localsolve(solver=solver)
 

--- a/gpkit/tests/test_model.py
+++ b/gpkit/tests/test_model.py
@@ -728,7 +728,7 @@ class TestSP:
         m = Model(x * y, Bounded(m, lower=0.001))
         sol = m.solve(solver, verbosity=0)
         bounds = sol.meta["boundedness"]
-        assert bounds["sensitive to lower bound of 0.001"] == set([x.key])
+        assert bounds["sensitive to lower bound of 0.001"] == {x.key}
         # end test one-sided bound
         m = Model(x * y, [x * y**1.01 >= 100])
         m = Model(x * y, Bounded(m))

--- a/gpkit/tests/test_nomials.py
+++ b/gpkit/tests/test_nomials.py
@@ -390,7 +390,7 @@ class TestPosynomial:
         m, g, h, v = (VarKey(s) for s in ("m", "g", "h", "v"))
         assert all(isinstance(x, float) for x in p.cs)
         assert len(p.exps) == 2
-        assert set(p.vks) == set([m, g, h, v])
+        assert set(p.vks) == {m, g, h, v}
 
     def test_eq(self):
         """Test Posynomial __eq__"""

--- a/gpkit/tests/test_nomials.py
+++ b/gpkit/tests/test_nomials.py
@@ -72,7 +72,7 @@ class TestMonomial:
 
         # test label kwarg
         x = Variable("x", label="dummy variable")
-        assert list(x.exp)[0].label == "dummy variable"
+        assert next(iter(x.exp)).label == "dummy variable"
         _ = hash(m)
         _ = hash(x)
         _ = hash(Monomial(x))

--- a/gpkit/tests/test_report.py
+++ b/gpkit/tests/test_report.py
@@ -1,6 +1,7 @@
 """Tests for gpkit/report.py: ReportSection IR, build_report_ir(), model.report()"""
 
 import json
+from typing import ClassVar
 
 import pytest
 
@@ -775,8 +776,8 @@ class TestModelDescription:
         class _DescAttrs(Model):
             """Aerodynamics model."""
 
-            assumptions = ["incompressible flow", "steady state"]
-            references = ["Anderson 2001"]
+            assumptions: ClassVar = ["incompressible flow", "steady state"]
+            references: ClassVar = ["Anderson 2001"]
 
             def setup(self):
                 x = Variable("x_desc_attrs")

--- a/gpkit/tests/test_report_descriptions.py
+++ b/gpkit/tests/test_report_descriptions.py
@@ -6,6 +6,8 @@ fields (references, front_matter, toc, objective_*), build_report_ir wiring,
 and renderer output for all new fields.
 """
 
+from typing import ClassVar
+
 import pytest
 
 from gpkit import Model, Variable
@@ -153,8 +155,8 @@ class TestBuildReportIRDescription:
         class _IRClassAttr(Model):
             """Structural model."""
 
-            assumptions = ["no buckling"]
-            references = ["Raymer 2018"]
+            assumptions: ClassVar = ["no buckling"]
+            references: ClassVar = ["Raymer 2018"]
 
             def setup(self):
                 x = Variable("x_ir_cls")

--- a/gpkit/tests/test_varmap.py
+++ b/gpkit/tests/test_varmap.py
@@ -224,7 +224,7 @@ class TestVarMap:
         x = Variable("x", lineage=(("test", 0),))
         vm[x] = 1
         assert x in vm
-        assert set(vm) == set([x.key])
+        assert set(vm) == {x.key}
 
 
 class TestRefLookup:

--- a/gpkit/toml/_expr.py
+++ b/gpkit/toml/_expr.py
@@ -294,7 +294,7 @@ def parse_objective(text, namespace):
     For ``"max: expr"``, returns ``1/expr``.
     """
     text = text.strip()
-    if text.startswith("min:") or text.startswith("max:"):
+    if text.startswith(("min:", "max:")):
         expr_str = text[4:].strip()
     else:
         raise TomlExpressionError(

--- a/gpkit/toml/_expr.py
+++ b/gpkit/toml/_expr.py
@@ -294,9 +294,7 @@ def parse_objective(text, namespace):
     For ``"max: expr"``, returns ``1/expr``.
     """
     text = text.strip()
-    if text.startswith("min:"):
-        expr_str = text[4:].strip()
-    elif text.startswith("max:"):
+    if text.startswith("min:") or text.startswith("max:"):
         expr_str = text[4:].strip()
     else:
         raise TomlExpressionError(

--- a/gpkit/toml/_parser.py
+++ b/gpkit/toml/_parser.py
@@ -430,18 +430,17 @@ def _build_multi_model(models_section, dimension_overrides=None):
         vec_length = _resolve_vectorize(model_def, all_dimensions)
         vec_ctx = Vectorize(vec_length) if vec_length else nullcontext()
 
-        with vec_ctx:
-            with NamedVariables(model_id) as (lineage, _):
-                ns, subs = _build_scalar_vars(_extract_model_vars(model_def))
-                substitutions.update(subs)
-                _build_vector_vars(
-                    model_def.get("vectors", {}),
-                    all_dimensions,
-                    ns,
-                    substitutions,
-                )
-                per_model_vars[model_id] = ns
-                per_model_lineage[model_id] = lineage
+        with vec_ctx, NamedVariables(model_id) as (lineage, _):
+            ns, subs = _build_scalar_vars(_extract_model_vars(model_def))
+            substitutions.update(subs)
+            _build_vector_vars(
+                model_def.get("vectors", {}),
+                all_dimensions,
+                ns,
+                substitutions,
+            )
+            per_model_vars[model_id] = ns
+            per_model_lineage[model_id] = lineage
 
     # Build merged namespace with ambiguity detection
     namespace = _build_merged_namespace(per_model_vars, all_dimensions)
@@ -532,10 +531,12 @@ def load_toml(source, *, dimensions=None, substitutions=None):
     -------
     gpkit.Model
     """
-    if isinstance(source, Path):
-        with open(source, "rb") as f:
-            doc = tomllib.load(f)
-    elif isinstance(source, str) and "\n" not in source and Path(source).is_file():
+    if (
+        isinstance(source, Path)
+        or isinstance(source, str)
+        and "\n" not in source
+        and Path(source).is_file()
+    ):
         with open(source, "rb") as f:
             doc = tomllib.load(f)
     elif isinstance(source, str):

--- a/gpkit/toml/_printer.py
+++ b/gpkit/toml/_printer.py
@@ -421,7 +421,7 @@ def _emit_single_model(ir, lines):
 
     if vector_groups:
         by_shape = {}
-        for _, group in vector_groups.items():
+        for group in vector_groups.values():
             shape = group["shape"]
             if isinstance(shape, (list, tuple)):
                 shape = shape[0] if len(shape) == 1 else tuple(shape)
@@ -539,7 +539,7 @@ def _emit_model_section(  # noqa: PLR0913, PLR0917
     # Vector variables as [models.X.vectors.N] sub-tables
     if vector_groups:
         by_shape = {}
-        for _, group in vector_groups.items():
+        for group in vector_groups.values():
             shape = group["shape"]
             if isinstance(shape, (list, tuple)):
                 shape = shape[0] if len(shape) == 1 else tuple(shape)

--- a/gpkit/toml/_printer.py
+++ b/gpkit/toml/_printer.py
@@ -510,7 +510,7 @@ def _emit_multi_model(ir, lines):
     )
 
 
-def _emit_model_section(  # noqa: PLR0913
+def _emit_model_section(  # noqa: PLR0913, PLR0917
     model_id,
     node,
     child_ids,

--- a/gpkit/tools/autosweep.py
+++ b/gpkit/tools/autosweep.py
@@ -268,7 +268,7 @@ def autosweep_1d(model, logtol, sweepvar, bounds, **solvekwargs):
     return bst
 
 
-def recurse_splits(model, bst, variable, logtol, solvekwargs, sols):  # noqa: PLR0913
+def recurse_splits(model, bst, variable, logtol, solvekwargs, sols):  # noqa: PLR0913, PLR0917
     "Recursively splits a BST until logtol is reached"
     x, lb, ub = get_tol(bst.costs, bst.bounds, bst.sols, variable)
     tol = (ub - lb) / 2.0

--- a/gpkit/units.py
+++ b/gpkit/units.py
@@ -1,5 +1,7 @@
 "wraps pint in gpkit monomials"
 
+from typing import ClassVar
+
 import pint
 
 ureg = pint.UnitRegistry()
@@ -20,9 +22,9 @@ def qty(unit):
 class GPkitUnits:
     "Return Monomials instead of Quantitites"
 
-    division_cache = {}
-    multiplication_cache = {}
-    monomial_cache = {}
+    division_cache: ClassVar = {}
+    multiplication_cache: ClassVar = {}
+    monomial_cache: ClassVar = {}
 
     def __call__(self, unity):
         "Returns a unit Monomial, caching the result for future retrievals"

--- a/gpkit/util/build.py
+++ b/gpkit/util/build.py
@@ -54,17 +54,19 @@ def call(cmd):
 
 def diff(filename, diff_dict):
     "Applies a simple diff to a file. Logs."
-    with open(filename, "r", encoding="utf-8") as a:
-        with open(filename + ".new", "w", encoding="utf-8") as b:
-            for line_number, line in enumerate(a):
-                if line[:-1].strip() in diff_dict:
-                    newline = diff_dict[line[:-1].strip()] + "\n"
-                    log(f"#\n#     Change in {filename} on line {line_number + 1}")
-                    log("#     --", line[:-1][:70])
-                    log("#     ++", newline[:70])
-                    b.write(newline)
-                else:
-                    b.write(line)
+    with (
+        open(filename, "r", encoding="utf-8") as a,
+        open(filename + ".new", "w", encoding="utf-8") as b,
+    ):
+        for line_number, line in enumerate(a):
+            if line[:-1].strip() in diff_dict:
+                newline = diff_dict[line[:-1].strip()] + "\n"
+                log(f"#\n#     Change in {filename} on line {line_number + 1}")
+                log("#     --", line[:-1][:70])
+                log("#     ++", newline[:70])
+                b.write(newline)
+            else:
+                b.write(line)
     shutil.move(filename + ".new", filename)
 
 
@@ -127,7 +129,7 @@ class MosekCLI(SolverBackend):
                 "# no version folders (e.g. '7', '8') found"
                 ' in mosek directory "{rootdir}"'
             )
-        version = sorted(possible_versions)[-1]
+        version = max(possible_versions)
         tools_dir = pathjoin(rootdir, version, "tools")
         lib_dir = pathjoin(tools_dir, "platform", mosek_platform)
         bin_dir = pathjoin(lib_dir, "bin")

--- a/gpkit/util/build.py
+++ b/gpkit/util/build.py
@@ -214,8 +214,9 @@ def build():
     envpath = "env"
     replacedir(envpath)
     with open(pathjoin(envpath, "settings"), "w", encoding="utf-8") as f:
-        for setting, value in sorted(settings.items()):
-            f.write(f"{setting} : {value}\n")
+        f.writelines(
+            f"{setting} : {value}\n" for setting, value in sorted(settings.items())
+        )
     with open(pathjoin(envpath, "build.log"), "w", encoding="utf-8") as f:
         f.write(LOGSTR)
 

--- a/gpkit/util/build.py
+++ b/gpkit/util/build.py
@@ -144,7 +144,7 @@ class MosekCLI(SolverBackend):
         try:
             if call("mskexpopt") in (1052, 28):  # 28 for MacOSX
                 return where
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001, S110
             pass  # exception type varies by operating system
         return None
 

--- a/gpkit/util/globals.py
+++ b/gpkit/util/globals.py
@@ -2,6 +2,7 @@
 
 import os
 from collections import defaultdict
+from typing import ClassVar
 
 from .build import build
 
@@ -24,7 +25,7 @@ def load_settings(path=None, trybuild=True):
                 # flatten 1-element lists unless they're the solver list
                 if len(value) == 1 and name != "installed_solvers":
                     (settings_[name],) = value
-    except IOError:  # pragma: no cover
+    except OSError:  # pragma: no cover
         settings_ = {"installed_solvers": [""]}
     if settings_["installed_solvers"] == [""] and trybuild:  # pragma: no cover
         print("Found no installed solvers, beginning a build.")
@@ -105,8 +106,8 @@ class NamedVariables:
     """
 
     lineage = ()  # the current model nesting
-    modelnums = defaultdict(int)  # the number of models of each lineage
-    namedvars = defaultdict(list)  # variables created in the current nesting
+    modelnums: ClassVar = defaultdict(int)  # the number of models of each lineage
+    namedvars: ClassVar = defaultdict(list)  # variables created in the current nesting
 
     @classmethod
     def reset_modelnumbers(cls):

--- a/gpkit/var.py
+++ b/gpkit/var.py
@@ -40,8 +40,8 @@ class Var:
         label: str = "",
         *,
         value=None,
-        latex: str = None,
-        growth: float = None,
+        latex: str | None = None,
+        growth: float | None = None,
     ):
         self.units = units
         self.label = label

--- a/gpkit/varkey.py
+++ b/gpkit/varkey.py
@@ -264,7 +264,7 @@ class VarKey(ReprMixin):
         "Returns a tuple of just the names of models in self.lineage"
         if not self.lineage:
             return ()
-        return tuple(zip(*self.lineage))[0]
+        return next(zip(*self.lineage))
 
     def latex(self, excluded=()):
         "Returns latex representation."

--- a/gpkit/varkey.py
+++ b/gpkit/varkey.py
@@ -9,7 +9,8 @@ from .units import qty
 from .util.repr_conventions import ReprMixin, extract_subscript, latexify
 from .util.small_classes import Count
 
-_lineage_ctx: ContextVar[dict] = ContextVar("lineage_ctx", default={})
+_lineage_ctx: ContextVar[dict | None] = ContextVar("lineage_ctx", default=None)
+_EMPTY_LINEAGE_MAP: dict = {}  # never mutated; shared read-only fallback
 
 
 @contextmanager
@@ -22,9 +23,14 @@ def lineage_display_context(mapping):
         _lineage_ctx.reset(token)
 
 
+def _current_lineage_map():
+    "Return the active lineage-depth mapping, or an empty one if unset."
+    return _lineage_ctx.get() or _EMPTY_LINEAGE_MAP
+
+
 def necessarylineage(vk):
     """Display lineage depth for a VarKey in the current context."""
-    return _lineage_ctx.get().get(vk)
+    return _current_lineage_map().get(vk)
 
 
 def _strip_magic_prefix(namespace, excluded):
@@ -181,7 +187,7 @@ class VarKey(ReprMixin):
                     if len(to_replace) > replaced:
                         namespace.insert(0, "." * (len(to_replace) - replaced))
             if "hiddenlineage" not in excluded:
-                lineage_map = _lineage_ctx.get()
+                lineage_map = _current_lineage_map()
                 lineage_depth = lineage_map.get(self)
                 if lineage_depth is None and self.veckey:
                     lineage_depth = lineage_map.get(self.veckey)
@@ -270,9 +276,10 @@ class VarKey(ReprMixin):
         if "lineage" not in excluded and self.lineage:
             namespace = _strip_magic_prefix(list(self.lineage), excluded)
             # Respect lineage_display_context depth (mirrors str_without)
-            depth = _lineage_ctx.get().get(self)
+            lineage_map = _current_lineage_map()
+            depth = lineage_map.get(self)
             if depth is None and self.veckey:
-                depth = _lineage_ctx.get().get(self.veckey)
+                depth = lineage_map.get(self.veckey)
             if depth is not None:
                 namespace = namespace[-depth:] if depth > 0 else []
             # Merge lineage into any existing subscript (name first, lineage last)

--- a/gpkit/varmap.py
+++ b/gpkit/varmap.py
@@ -190,11 +190,11 @@ class VarMap(MutableMapping):
         key = self._varset.resolve(key)
         try:
             return (key, self._data[key])  # single varkey case
-        except KeyError as kerr:
+        except KeyError:
             key_arr = self._varset.by_vec(key)
             if key_arr.any():
                 return (key, _nested_lookup(key_arr, self._data))
-            raise kerr
+            raise
 
     @property
     def varset(self):

--- a/gpkit/varmap.py
+++ b/gpkit/varmap.py
@@ -213,7 +213,7 @@ class VarMap(MutableMapping):
         if is_veckey(key):
             if key not in self._varset._by_vec:
                 raise NotImplementedError
-            if hasattr(value, "__call__"):  # a linked vector-function
+            if callable(value):  # a linked vector-function
                 fn = value
                 value = np.empty(key.shape, dtype="object")
                 it = np.nditer(value, flags=["multi_index", "refs_ok"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,11 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+# These deliberately assert `not (x == y)`/`not (x != y)` alongside `!=`/`==`
+# to test __eq__ and __ne__ independently on classes with custom equality.
+"gpkit/tests/test_constraints.py" = ["SIM201", "SIM202"]
+"gpkit/tests/test_nomials.py" = ["SIM201", "SIM202"]
+"gpkit/tests/test_vars.py" = ["SIM201", "SIM202"]
 
 [tool.pytest.ini_options]
 testpaths = ["gpkit/tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ extend-select = [
 ignore = [
     "PLR2004",  # magic-value-comparison: noisy, no precedent, revisit later
     "PLW2901",  # redefined-loop-name: idiomatic here, bulk-fix risks bugs
+    "UP031",    # printf-string-formatting: 47 sites (mostly breakdowns.py,
+                # interactive/sankey.py) not yet converted to f-strings; see #220
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/scripts/regen_examples.py
+++ b/scripts/regen_examples.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Regenerate output files for catalog-eligible examples.
 
 Reads catalog.toml to discover which gpkit.examples.* scripts to run (no


### PR DESCRIPTION
## Summary

CI's Lint job was failing while local pre-commit passed clean. Root cause: `uv.lock` isn't committed, so local and CI independently resolve `ruff` versions with no lockfile to keep them in sync — local had `ruff==0.15.21`, CI had `ruff==0.16.1`. Ruff 0.16.0 expanded its default rule set from 59 to 413 rules, so the version bump silently enabled ~354 rule categories this repo never selected, surfacing ~175 violations with no actual code regression behind them.

Fixed 128 of those 175 violations across every newly-enabled category except one deliberately deferred case:

- **Real bugs found and fixed along the way** (not just lint noise):
  - A mutable-default-argument bug in `breakdowns.get_fixity` (`visited=set()`) — the only caller never passed `visited` explicitly, so state silently accumulated across every unrelated breakdown computation for the life of the process, causing later calls to wrongly treat previously-visited keys as already-checked.
  - A missing `f`-string prefix in `CostedConstraintSet`'s vector-cost error message — it was printing `"...vector {cost}."` literally instead of interpolating the value.
  - A mutable `ContextVar` default in `varkey.py` (`ContextVar("lineage_ctx", default={})`) — the same class of shallow-copy-across-contexts hazard fixed on the `globals` branch for `NamedVariables`'s asyncio leak. Verified this one was benign in practice (only ever read via `.get(vk)`, never mutated in place), but hardened it anyway for consistency and future-proofing.
- **`RUF012`** (14 sites): annotated genuinely shared/read-only class attributes with `ClassVar`.
- **Mechanical rewrites**: `B004`, `C400/401/405/408`, `SIM102/103/117`, `PERF102`, `RUF013/015/046`, `TRY201`, `FLY002`, `FURB192`, `PIE810`, `EXE001`, `ISC004`.
- **Deliberate suppressions, each with documented rationale**:
  - `SIM201`/`SIM202` in three test files, moved to `pyproject.toml`'s `per-file-ignores` — these tests intentionally assert `not (x == y)` alongside `x != y` to exercise `__eq__` and `__ne__` independently on classes with custom equality; collapsing them would remove real coverage.
  - `B023` in `interactive/sankey.py` — confirmed safe: the flagged closure is invoked synchronously inside `filter()`, so there's no late-binding hazard despite the general pattern being risky.
  - `S110` in `util/build.py` — already-documented cross-platform `except Exception: pass`, extended its existing noqa.
- **One deliberate behavior change**: `CostedConstraintSet`'s vector-cost check now raises `TypeError` instead of `ValueError` (matches ruff's `TRY004` recommendation and is the more correct exception type); updated the one test that pinned the old exception type. No back-compat shim, per this repo's pre-1.0 free-breakage convention.

## Deferred

`UP031` (47 `%`-style string-formatting sites, concentrated in `breakdowns.py` and `interactive/sankey.py`) is suppressed via `pyproject.toml`'s `ignore` list rather than fixed inline — real, reviewable work rather than a rushed mechanical pass. Tracked in #220.

`uv.lock` remains uncommitted — the general fix for version-drift-causes-CI-surprises is tracked separately in #92 (dependency update automation), out of scope here.

## Test plan

- [x] `uvx ruff@0.16.1 check .` — matches CI's resolved version — passes clean
- [x] `uv run ruff check .` — local resolved version — passes clean
- [x] `uvx ruff@0.16.1 format --check .` / `uv run ruff format --check .` — both clean
- [x] `uv run pre-commit run --all-files` — the exact command CI runs — all three hooks pass
- [x] `uv run pytest gpkit/tests -q` — 805 passed, 2 skipped (pre-existing solver-dependent skips)